### PR TITLE
Fix 'Error! No Localizable.strings file found for output.'

### DIFF
--- a/Sources/Code/CommandLineActor.swift
+++ b/Sources/Code/CommandLineActor.swift
@@ -64,7 +64,7 @@ public class CommandLineActor {
     
     private func actOnCode(path path: String, override: Bool, verbose: Bool, localizable: String, defaultToKeys: Bool, additive: Bool) {
         
-        let allLocalizableStringsFilePaths = StringsFilesSearch.sharedInstance.findAllStringsFiles(path, withFileName: "Localizable")
+        let allLocalizableStringsFilePaths = StringsFilesSearch.sharedInstance.findAllStringsFiles(localizable, withFileName: "Localizable")
         
         guard !allLocalizableStringsFilePaths.isEmpty else {
             self.printError("No `Localizable.strings` file found for output.")


### PR DESCRIPTION
To reproduce the bug - just try to use the "code" command.
`bartycrouch code -p "/path/to/swift/classes/" -l "/paht/to/Localizable.strings_folders/" -a -v`

it returns:
```
"Error! No `Localizable.strings` file found for output." 
```
when the path to Localizable strings is actually correct.

The bug originates from this commit:

> Commit: 5443d82799cfde8bc24533c15db5e521b846a407 [5443d82]
> Parents: 1c7e8682d1
> Author: Cihat Gündüz <CihatGuenduez@posteo.de>
> Date: May 5, 2016 at 21:23:16 GMT+3
> 
> Fix issues to get code extraction running

where the actOnCode method is refactored and "localizable" argument is left out un-used.