### PR TITLE
Add option to parse custom functions

### DIFF
--- a/BartyCrouch.xcodeproj/xcshareddata/xcschemes/BartyCrouch.xcscheme
+++ b/BartyCrouch.xcodeproj/xcshareddata/xcschemes/BartyCrouch.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0720"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "82CDE27E1C6ABF3A00055FE6"
+               BuildableName = "BartyCrouch.framework"
+               BlueprintName = "BartyCrouch"
+               ReferencedContainer = "container:BartyCrouch.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "82CDE2871C6ABF3A00055FE6"
+               BuildableName = "BartyCrouchTests.xctest"
+               BlueprintName = "BartyCrouchTests"
+               ReferencedContainer = "container:BartyCrouch.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "82CDE27E1C6ABF3A00055FE6"
+            BuildableName = "BartyCrouch.framework"
+            BlueprintName = "BartyCrouch"
+            ReferencedContainer = "container:BartyCrouch.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "82CDE27E1C6ABF3A00055FE6"
+            BuildableName = "BartyCrouch.framework"
+            BlueprintName = "BartyCrouch"
+            ReferencedContainer = "container:BartyCrouch.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "82CDE27E1C6ABF3A00055FE6"
+            BuildableName = "BartyCrouch.framework"
+            BlueprintName = "BartyCrouch"
+            ReferencedContainer = "container:BartyCrouch.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ $ bartycrouch interfaces -p "/absolute/path/to/project"
 # Updates `Localizable.strings` files with new keys searching your code for `NSLocalizedString`
 $ bartycrouch code -p "/path/to/code/directory" -l "/directory/containing/all/Localizables" -a
 
+# Updates `Localizable.strings` files with new keys searching your code for `YourCustomFunction`. Useful when you are using something else than `NSLocalizedString`
+$ bartycrouch code -p "/path/to/code/directory" -l "/directory/containing/all/Localizables" -a -c "YourCustomFunction"
+
 # Machine-translate all empty localization values using English as source language
 $ bartycrouch translate -p "/path/to/project" -l en -i "<API_ID>" -s "<API_SECRET>"
 ```
@@ -206,6 +209,14 @@ Example:
 
 ```shell
 $ bartycrouch code -p "/path/to/code/files", -l "/path/to/localizables" -a
+```
+
+#### Custom Function (aka `-c`, `--customFunction`) <small>*optional*</small>
+
+If you use a custom function(macro) in your code to localize the strings instead of NSLocalizedString, you may specify it using this option. BartyCrouch will parse the code for the name you give instead of the default NSLocalizedString. Your functions must use the naming and formatting conventions used by the Foundation macros. The parameters for your functions must match the parameters for the corresponding macros exactly. The parsing is done using "genstrings" tool. You may see more in <a href="https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/LoadingResources/Strings/Strings.html">Apple's documentation</a> about it. Look into "Searching for Custom Functions With genstrings" section.
+
+```shell
+$ bartycrouch code -p "/path/to/code/files" -l "/path/to/Localizables" -c "YourCustomFunction"
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Here's an overview of all options available for the sub command `code`:
 - `localizable` (required)
 - `default-to-keys`
 - `additive`
+- `customFunction`
 
 #### Localizable (aka `-l`, `--localizable`) <small>*required*</small>
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@
     </a>
 </p>
 
+<p align="center">
+    <a href="#installation">Installation</a>
+  • <a href="#dialog-usage">Usage</a>
+  • <a href="#build-script">Build Script</a>
+  • <a href="#migration-guides">Migration Guides</a>
+  • <a href="https://github.com/Flinesoft/BartyCrouch/issues">Issues</a>
+  • <a href="#license">License</a>
+</p>
+
 
 # BartyCrouch
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 <p align="center">
     <a href="#installation">Installation</a>
-  • <a href="#dialog-usage">Usage</a>
+  • <a href="#usage">Usage</a>
   • <a href="#build-script">Build Script</a>
   • <a href="#migration-guides">Migration Guides</a>
   • <a href="https://github.com/Flinesoft/BartyCrouch/issues">Issues</a>

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Here's an overview of all options available for the sub command `code`:
 - `default-to-keys`
 - `additive`
 
-#### Localizable (aka `-l`, `--localizable`)
+#### Localizable (aka `-l`, `--localizable`) <small>*required*</small>
 
 Specifies the path to the directory which contains all `Localizable.strings` files within `<locale>.lproj` folders. BartyCrouch will search for all files named `Localizable.strings` recursively within the specified path and incrementally update them. Make sure to specify a path with only your projects `Localizable.strings` files.
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
   • <a href="#build-script">Build Script</a>
   • <a href="#migration-guides">Migration Guides</a>
   • <a href="https://github.com/Flinesoft/BartyCrouch/issues">Issues</a>
+  • <a href="#contributing">Contributing</a>
   • <a href="#license">License</a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 
 <p align="center">
     <a href="https://github.com/Flinesoft/BartyCrouch/releases">
-        <img src="https://img.shields.io/badge/Version-3.0.0-blue.svg"
-             alt="Version: 3.0.0">
+        <img src="https://img.shields.io/badge/Version-3.0.1-blue.svg"
+             alt="Version: 3.0.1">
     </a>
     <a href="#">
         <img src="https://img.shields.io/badge/Swift-2.2-DD563C.svg"

--- a/Sources/Code/CommandLineActor.swift
+++ b/Sources/Code/CommandLineActor.swift
@@ -30,13 +30,13 @@ public class CommandLineActor {
         
         
         switch subCommandOptions {
-        case let .CodeOptions(localizableOption, defaultToKeysOption, additiveOption):
+        case let .CodeOptions(localizableOption, defaultToKeysOption, additiveOption, customFunction):
             guard let localizable = localizableOption.value else {
                 self.printError("Localizable option `-l` is missing.")
                 exit(EX_USAGE)
             }
             
-            self.actOnCode(path: path, override: override, verbose: verbose, localizable: localizable, defaultToKeys: defaultToKeysOption.value, additive: additiveOption.value)
+            self.actOnCode(path: path, override: override, verbose: verbose, localizable: localizable, defaultToKeys: defaultToKeysOption.value, additive: additiveOption.value, customFunction: customFunction.value)
             
         case let .InterfacesOptions(defaultToBaseOption):
             self.actOnInterfaces(path: path, override: override, verbose: verbose, defaultToBase: defaultToBaseOption.value)
@@ -62,7 +62,7 @@ public class CommandLineActor {
         
     }
     
-    private func actOnCode(path path: String, override: Bool, verbose: Bool, localizable: String, defaultToKeys: Bool, additive: Bool) {
+    private func actOnCode(path path: String, override: Bool, verbose: Bool, localizable: String, defaultToKeys: Bool, additive: Bool, customFunction: String?) {
         
         let allLocalizableStringsFilePaths = StringsFilesSearch.sharedInstance.findAllStringsFiles(localizable, withFileName: "Localizable")
         
@@ -80,7 +80,7 @@ public class CommandLineActor {
             
         }
         
-        self.incrementalCodeUpdate(path, allLocalizableStringsFilePaths, override: override, verbose: verbose, defaultToKeys: defaultToKeys, additive: additive)
+        self.incrementalCodeUpdate(path, allLocalizableStringsFilePaths, override: override, verbose: verbose, defaultToKeys: defaultToKeys, additive: additive, customFunction: customFunction)
         
     }
     
@@ -147,7 +147,7 @@ public class CommandLineActor {
         
     }
     
-    private func incrementalCodeUpdate(inputDirectoryPath: String, _ outputStringsFilePaths: [String], override: Bool, verbose: Bool, defaultToKeys: Bool, additive: Bool) {
+    private func incrementalCodeUpdate(inputDirectoryPath: String, _ outputStringsFilePaths: [String], override: Bool, verbose: Bool, defaultToKeys: Bool, additive: Bool, customFunction: String?) {
         
         let extractedStringsFileDirectory = inputDirectoryPath + "/tmpstrings/"
         
@@ -158,7 +158,7 @@ public class CommandLineActor {
             exit(EX_IOERR)
         }
         
-        guard GenStringsCommander.sharedInstance.export(stringsFilesToPath: extractedStringsFileDirectory, fromCodeInDirectoryPath: inputDirectoryPath) else {
+        guard GenStringsCommander.sharedInstance.export(stringsFilesToPath: extractedStringsFileDirectory, fromCodeInDirectoryPath: inputDirectoryPath, customFunction: customFunction) else {
             self.printError("Could not extract strings from Code in directory '\(inputDirectoryPath)'.")
             exit(EX_UNAVAILABLE)
         }

--- a/Sources/Code/CommandLineActor.swift
+++ b/Sources/Code/CommandLineActor.swift
@@ -64,7 +64,7 @@ public class CommandLineActor {
     
     private func actOnCode(path path: String, override: Bool, verbose: Bool, localizable: String, defaultToKeys: Bool, additive: Bool) {
         
-        let allLocalizableStringsFilePaths = StringsFilesSearch.sharedInstance.findAllStringsFiles(path, withFileName: "Localizable")
+        let allLocalizableStringsFilePaths = StringsFilesSearch.sharedInstance.findAllStringsFiles(localizable, withFileName: "Localizable")
         
         guard !allLocalizableStringsFilePaths.isEmpty else {
             self.printError("No `Localizable.strings` file found for output.")

--- a/Sources/Code/CommandLineParser.swift
+++ b/Sources/Code/CommandLineParser.swift
@@ -26,7 +26,7 @@ public class CommandLineParser {
     private typealias CommandLineContext = (commandLine: CommandLine, commonOptions: CommonOptions, subCommandOptions: SubCommandOptions)
     
     public enum SubCommandOptions {
-        case CodeOptions(localizable: StringOption, defaultToKeys: BoolOption, additive: BoolOption)
+        case CodeOptions(localizable: StringOption, defaultToKeys: BoolOption, additive: BoolOption, customFunction: StringOption)
         case InterfacesOptions(defaultToBase: BoolOption)
         case TranslateOptions(id: StringOption, secret: StringOption, locale: StringOption)
     }
@@ -149,11 +149,18 @@ public class CommandLineParser {
             helpMessage: "Only adds new keys keeping all existing keys even when seemingly unused."
         )
         
+        let customFunction = StringOption(
+            shortFlag: "c",
+            longFlag: "customFunction",
+            required: false,
+            helpMessage: "Specifies custom function to be parsed by genstrings, instead of the default NSLocalizedString. Will invoke 'genstrings -s \"yourCustomFunctionName\"'"
+        )
+        
         
         let commonOptions: CommonOptions = (path: path, override: override, verbose: verbose)
-        let subCommandOptions = SubCommandOptions.CodeOptions(localizable: localizable, defaultToKeys: defaultToKeys, additive: additive)
+        let subCommandOptions = SubCommandOptions.CodeOptions(localizable: localizable, defaultToKeys: defaultToKeys, additive: additive, customFunction: customFunction)
         
-        commandLine.addOptions(path, localizable, override, verbose, defaultToKeys, additive)
+        commandLine.addOptions(path, localizable, override, verbose, defaultToKeys, additive, customFunction)
         
         return (commandLine, commonOptions, subCommandOptions)
         

--- a/Sources/Code/GenStringsCommander.swift
+++ b/Sources/Code/GenStringsCommander.swift
@@ -18,9 +18,10 @@ public class GenStringsCommander {
     
     // MARK: - Instance Methods
     
-    public func export(stringsFilesToPath stringsFilePath: String, fromCodeInDirectoryPath codeDirectoryPath: String) -> Bool {
+    public func export(stringsFilesToPath stringsFilePath: String, fromCodeInDirectoryPath codeDirectoryPath: String, customFunction: String?) -> Bool {
         
-        let exitCode = system("find \"\(codeDirectoryPath)\" -name '*.[hm]' -o -name '*.swift' | xargs genstrings -o \"\(stringsFilePath)\"")
+        let customFunctionAddon: String = customFunction != nil ? "-s '\(customFunction!)'" : ""
+        let exitCode = system("find \"\(codeDirectoryPath)\" -name '*.[hm]' -o -name '*.swift' | xargs genstrings -o \"\(stringsFilePath)\" \(customFunctionAddon)")
         
         if exitCode == 0 {
             return true

--- a/Sources/Supporting Files/Info.plist
+++ b/Sources/Supporting Files/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.0</string>
+	<string>3.0.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
In cases like <a href="http://stackoverflow.com/questions/9939885/manual-language-selection-in-an-ios-app-iphone-and-ipad">this one </a> where you may use custom function/macro instead of NSLocalizedString you need a way to tell the tool to parse your function name. It uses "genstrings" to extract the strings and it has this "-s functionName" argument so I just added it as an option.
I've named it "customFunction" with "c" as shorthand. 

This is the way you use it:
`$ bartycrouch code -p "/path/to/code/files" -l "/path/to/Localizables" -c "YourCustomFunction"`

I've updated the Readme about the new feature.
I used the tool in such case so I needed this feature added :) 