### PR TITLE
Add -e extractLocStrings option

### DIFF
--- a/BartyCrouch.xcodeproj/project.pbxproj
+++ b/BartyCrouch.xcodeproj/project.pbxproj
@@ -48,6 +48,14 @@
 		A1FF9DA21D9324F900D5E85E /* Option.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FF9D9D1D9324F900D5E85E /* Option.swift */; };
 		A1FF9DA31D9324F900D5E85E /* StringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FF9D9E1D9324F900D5E85E /* StringExtensions.swift */; };
 		A1FF9DA41D9324F900D5E85E /* StringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FF9D9E1D9324F900D5E85E /* StringExtensions.swift */; };
+		E78B1E141DFAB33200C7C290 /* ExtractLocStringsCommander.swift in Sources */ = {isa = PBXBuildFile; fileRef = E78B1E131DFAB33200C7C290 /* ExtractLocStringsCommander.swift */; };
+		E78B1E151DFAB33900C7C290 /* ExtractLocStringsCommander.swift in Sources */ = {isa = PBXBuildFile; fileRef = E78B1E131DFAB33200C7C290 /* ExtractLocStringsCommander.swift */; };
+		E78B1E171DFABA5500C7C290 /* CodeCommander.swift in Sources */ = {isa = PBXBuildFile; fileRef = E78B1E161DFABA5500C7C290 /* CodeCommander.swift */; };
+		E78B1E181DFABB1900C7C290 /* CodeCommander.swift in Sources */ = {isa = PBXBuildFile; fileRef = E78B1E161DFABA5500C7C290 /* CodeCommander.swift */; };
+		E7974AF31DFAE9DF00E31754 /* ExtractLocStringsCommanderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7974AF11DFAE9AA00E31754 /* ExtractLocStringsCommanderTests.swift */; };
+		E7974AFD1DFAECA700E31754 /* SwiftExample2Arguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7974AFA1DFAECA700E31754 /* SwiftExample2Arguments.swift */; };
+		E7974AFE1DFAECA700E31754 /* SwiftExample3Arguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7974AFC1DFAECA700E31754 /* SwiftExample3Arguments.swift */; };
+		E7974B011DFAFD2D00E31754 /* SwiftExample4Arguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7974B001DFAFD2D00E31754 /* SwiftExample4Arguments.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -132,6 +140,12 @@
 		A1FF9D9C1D9324F900D5E85E /* CommandLineKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CommandLineKit.swift; path = Carthage/Checkouts/CommandLine/CommandLineKit/CommandLineKit.swift; sourceTree = SOURCE_ROOT; };
 		A1FF9D9D1D9324F900D5E85E /* Option.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Option.swift; path = Carthage/Checkouts/CommandLine/CommandLineKit/Option.swift; sourceTree = SOURCE_ROOT; };
 		A1FF9D9E1D9324F900D5E85E /* StringExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StringExtensions.swift; path = Carthage/Checkouts/CommandLine/CommandLineKit/StringExtensions.swift; sourceTree = SOURCE_ROOT; };
+		E78B1E131DFAB33200C7C290 /* ExtractLocStringsCommander.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtractLocStringsCommander.swift; sourceTree = "<group>"; };
+		E78B1E161DFABA5500C7C290 /* CodeCommander.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CodeCommander.swift; sourceTree = "<group>"; };
+		E7974AF11DFAE9AA00E31754 /* ExtractLocStringsCommanderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtractLocStringsCommanderTests.swift; sourceTree = "<group>"; };
+		E7974AFA1DFAECA700E31754 /* SwiftExample2Arguments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftExample2Arguments.swift; sourceTree = "<group>"; };
+		E7974AFC1DFAECA700E31754 /* SwiftExample3Arguments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftExample3Arguments.swift; sourceTree = "<group>"; };
+		E7974B001DFAFD2D00E31754 /* SwiftExample4Arguments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftExample4Arguments.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -187,7 +201,9 @@
 				824DAA5C1CDB60E00077F93A /* CommandLineActor.swift */,
 				82125E921D0312CF00B9C66B /* Commander.swift */,
 				82CDE2EA1C6BF9D900055FE6 /* IBToolCommander.swift */,
+				E78B1E161DFABA5500C7C290 /* CodeCommander.swift */,
 				82463DF91CD910FD00D28A2C /* GenStringsCommander.swift */,
+				E78B1E131DFAB33200C7C290 /* ExtractLocStringsCommander.swift */,
 				824DAA681CDB80310077F93A /* Helpers */,
 			);
 			name = "Command Line";
@@ -226,6 +242,7 @@
 				824DAA601CDB61140077F93A /* CommandLineActorTests.swift */,
 				82CDE2EC1C6BFE8F00055FE6 /* IBToolCommanderTests.swift */,
 				82463E0A1CD9197600D28A2C /* GenStringsCommanderTests.swift */,
+				E7974AF11DFAE9AA00E31754 /* ExtractLocStringsCommanderTests.swift */,
 			);
 			name = "Command Line";
 			sourceTree = "<group>";
@@ -332,6 +349,7 @@
 		82CDE26C1C6ABC0200055FE6 /* Assets */ = {
 			isa = PBXGroup;
 			children = (
+				E7974AF81DFAECA700E31754 /* Multiple Arguments Code */,
 				82463E011CD915DB00D28A2C /* Code Files */,
 				82CDE2F81C6C0BAA00055FE6 /* Strings Files */,
 				82CDE2FF1C6C0BAA00055FE6 /* Storyboards */,
@@ -402,6 +420,40 @@
 			);
 			name = Polyglot;
 			path = Checkouts/Polyglot/Polyglot;
+			sourceTree = "<group>";
+		};
+		E7974AF81DFAECA700E31754 /* Multiple Arguments Code */ = {
+			isa = PBXGroup;
+			children = (
+				E7974AF91DFAECA700E31754 /* 2 Arguments */,
+				E7974AFB1DFAECA700E31754 /* 3 Arguments */,
+				E7974AFF1DFAFD1D00E31754 /* 4 Arguments */,
+			);
+			path = "Multiple Arguments Code";
+			sourceTree = "<group>";
+		};
+		E7974AF91DFAECA700E31754 /* 2 Arguments */ = {
+			isa = PBXGroup;
+			children = (
+				E7974AFA1DFAECA700E31754 /* SwiftExample2Arguments.swift */,
+			);
+			path = "2 Arguments";
+			sourceTree = "<group>";
+		};
+		E7974AFB1DFAECA700E31754 /* 3 Arguments */ = {
+			isa = PBXGroup;
+			children = (
+				E7974AFC1DFAECA700E31754 /* SwiftExample3Arguments.swift */,
+			);
+			path = "3 Arguments";
+			sourceTree = "<group>";
+		};
+		E7974AFF1DFAFD1D00E31754 /* 4 Arguments */ = {
+			isa = PBXGroup;
+			children = (
+				E7974B001DFAFD2D00E31754 /* SwiftExample4Arguments.swift */,
+			);
+			path = "4 Arguments";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -568,11 +620,13 @@
 				82DD98381C7DE18B0065F046 /* Polyglot.swift in Sources */,
 				828ED5371C710C3100E0E947 /* StringsFilesSearch.swift in Sources */,
 				824DAA641CDB6F520077F93A /* SubCommander.swift in Sources */,
+				E78B1E151DFAB33900C7C290 /* ExtractLocStringsCommander.swift in Sources */,
 				82CDE2761C6ABE5D00055FE6 /* main.swift in Sources */,
 				A140FE0F1D4BD6FB001E0C4B /* Commander.swift in Sources */,
 				82DD98391C7DE18B0065F046 /* Session.swift in Sources */,
 				824DAA5E1CDB60E00077F93A /* CommandLineActor.swift in Sources */,
 				A1FF9DA41D9324F900D5E85E /* StringExtensions.swift in Sources */,
+				E78B1E181DFABB1900C7C290 /* CodeCommander.swift in Sources */,
 				824DAA5F1CDB60E90077F93A /* GenStringsCommander.swift in Sources */,
 				82053A241CD3221900434DAD /* StringExtensionPolyglot.swift in Sources */,
 			);
@@ -584,17 +638,22 @@
 			files = (
 				82125E931D0312CF00B9C66B /* Commander.swift in Sources */,
 				82DD98361C7DE1560065F046 /* Session.swift in Sources */,
+				E78B1E141DFAB33200C7C290 /* ExtractLocStringsCommander.swift in Sources */,
 				824DAA5D1CDB60E00077F93A /* CommandLineActor.swift in Sources */,
 				A1FF9D9F1D9324F900D5E85E /* CommandLineKit.swift in Sources */,
 				821DED3A1C70CFBB00B8353B /* StringsFilesSearch.swift in Sources */,
 				82CDE2E01C6BF35500055FE6 /* StringsFileUpdater.swift in Sources */,
+				E7974AFE1DFAECA700E31754 /* SwiftExample3Arguments.swift in Sources */,
 				82463DFA1CD910FD00D28A2C /* GenStringsCommander.swift in Sources */,
+				E7974AFD1DFAECA700E31754 /* SwiftExample2Arguments.swift in Sources */,
+				E7974B011DFAFD2D00E31754 /* SwiftExample4Arguments.swift in Sources */,
 				A1FF9DA11D9324F900D5E85E /* Option.swift in Sources */,
 				82053A231CD3221900434DAD /* StringExtensionPolyglot.swift in Sources */,
 				82CDE2EB1C6BF9D900055FE6 /* IBToolCommander.swift in Sources */,
 				A1FF9DA31D9324F900D5E85E /* StringExtensions.swift in Sources */,
 				82DD98351C7DE1560065F046 /* Polyglot.swift in Sources */,
 				824DAA6A1CDB80E10077F93A /* CommandLineParser.swift in Sources */,
+				E78B1E171DFABA5500C7C290 /* CodeCommander.swift in Sources */,
 				824DAA631CDB6F520077F93A /* SubCommander.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -607,6 +666,7 @@
 				821DED3C1C70D04B00B8353B /* StringsFilesSearchTests.swift in Sources */,
 				82463E0B1CD9197600D28A2C /* GenStringsCommanderTests.swift in Sources */,
 				824DAA6D1CDBA55F0077F93A /* CommandLineParserTests.swift in Sources */,
+				E7974AF31DFAE9DF00E31754 /* ExtractLocStringsCommanderTests.swift in Sources */,
 				82CDE2EF1C6BFE9D00055FE6 /* StringsFileUpdaterTests.swift in Sources */,
 				8278A9001CA129C30041B196 /* Constants.m in Sources */,
 				824DAA611CDB61140077F93A /* CommandLineActorTests.swift in Sources */,

--- a/Sources/Code/CodeCommander.swift
+++ b/Sources/Code/CodeCommander.swift
@@ -1,0 +1,24 @@
+//
+//  BaseCodeCommander.swift
+//  BartyCrouch
+//
+//  Created by Fyodor Volchyok on 12/9/16.
+//  Copyright © 2016 Flinesoft. All rights reserved.
+//
+
+import Foundation
+
+protocol CodeCommander {
+
+    func export(stringsFilesToPath stringsFilePath: String, fromCodeInDirectoryPath codeDirectoryPath: String) -> Bool
+
+}
+
+extension CodeCommander {
+
+    func findFiles(in codeDirectoryPath: String) -> Commander.CommandLineResult {
+        return Commander.sharedInstance.run(command: "/usr/bin/find", arguments:
+            [codeDirectoryPath, "-name", "*.[hm]", "-o", "-name", "*.mm", "-o", "-name", "*.swift"])
+    }
+
+}

--- a/Sources/Code/CommandLineParser.swift
+++ b/Sources/Code/CommandLineParser.swift
@@ -26,7 +26,7 @@ public class CommandLineParser {
     private typealias CommandLineContext = (commandLine: CommandLineKit, commonOptions: CommonOptions, subCommandOptions: SubCommandOptions)
 
     public enum SubCommandOptions {
-        case CodeOptions(localizable: StringOption, defaultToKeys: BoolOption, additive: BoolOption, overrideComments: BoolOption)
+        case CodeOptions(localizable: StringOption, defaultToKeys: BoolOption, additive: BoolOption, overrideComments: BoolOption, useExtractLocStrings: BoolOption)
         case InterfacesOptions(defaultToBase: BoolOption)
         case TranslateOptions(id: StringOption, secret: StringOption, locale: StringOption)
     }
@@ -156,15 +156,23 @@ public class CommandLineParser {
             helpMessage: "Overrides existing translation comments."
         )
 
+        let useExtractLocStrings = BoolOption(
+            shortFlag: "e",
+            longFlag: "extract-loc-strings",
+            required: false,
+            helpMessage: "Uses extractLocStrings instead of genstrings"
+        )
+
         let commonOptions: CommonOptions = (path: path, override: override, verbose: verbose)
         let subCommandOptions = SubCommandOptions.CodeOptions(
             localizable: localizable,
             defaultToKeys: defaultToKeys,
             additive: additive,
-            overrideComments: overrideComments
+            overrideComments: overrideComments,
+            useExtractLocStrings: useExtractLocStrings
         )
 
-        commandLine.addOptions(path, localizable, override, verbose, defaultToKeys, additive, overrideComments)
+        commandLine.addOptions(path, localizable, override, verbose, defaultToKeys, additive, overrideComments, useExtractLocStrings)
 
         return (commandLine, commonOptions, subCommandOptions)
 

--- a/Sources/Code/ExtractLocStringsCommander.swift
+++ b/Sources/Code/ExtractLocStringsCommander.swift
@@ -1,0 +1,29 @@
+//
+//  ExtractLocStringsCommander.swift
+//  BartyCrouch
+//
+//  Created by Fyodor Volchyok on 12.09.16.
+//  Copyright © 2016 Flinesoft. All rights reserved.
+//
+
+import Foundation
+
+/// Sends `xcrun extractLocStrings` commands with specified input/output paths to bash.
+public class ExtractLocStringsCommander: CodeCommander {
+
+    // MARK: - Stored Class Properties
+
+    public static let sharedInstance = ExtractLocStringsCommander()
+
+
+    // MARK: - Instance Methods
+
+    public func export(stringsFilesToPath stringsFilePath: String, fromCodeInDirectoryPath codeDirectoryPath: String) -> Bool {
+        let findFilesResult = findFiles(in: codeDirectoryPath)
+
+        let exportFileResult = Commander.sharedInstance.run(command: "/usr/bin/xcrun", arguments: ["extractLocStrings"] + findFilesResult.outputs + ["-o", stringsFilePath])
+
+        return findFilesResult.exitCode == 0 && exportFileResult.exitCode == 0
+    }
+
+}

--- a/Sources/Code/GenStringsCommander.swift
+++ b/Sources/Code/GenStringsCommander.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// Sends `genstrings` commands with specified input/output paths to bash.
-public class GenStringsCommander {
+public class GenStringsCommander: CodeCommander {
 
     // MARK: - Stored Class Properties
 
@@ -19,16 +19,11 @@ public class GenStringsCommander {
     // MARK: - Instance Methods
 
     public func export(stringsFilesToPath stringsFilePath: String, fromCodeInDirectoryPath codeDirectoryPath: String) -> Bool {
-        let findFilesResult = Commander.sharedInstance.run(command: "/usr/bin/find", arguments:
-            [codeDirectoryPath, "-name", "*.[hm]", "-o", "-name", "*.mm", "-o", "-name", "*.swift"])
+        let findFilesResult = findFiles(in: codeDirectoryPath)
 
         let exportFileResult = Commander.sharedInstance.run(command: "/usr/bin/genstrings", arguments: findFilesResult.outputs + ["-o", stringsFilePath])
 
-        if findFilesResult.exitCode == 0 && exportFileResult.exitCode == 0 {
-            return true
-        } else {
-            return false
-        }
+        return findFilesResult.exitCode == 0 && exportFileResult.exitCode == 0
     }
 
 }

--- a/Tests/Assets/Multiple Arguments Code/2 Arguments/SwiftExample2Arguments.swift
+++ b/Tests/Assets/Multiple Arguments Code/2 Arguments/SwiftExample2Arguments.swift
@@ -1,0 +1,13 @@
+//
+//  SwiftExample2Arguments.swift
+//  BartyCrouch
+//
+//  Created by Fyodor Volchyok on 12/9/16.
+//  Copyright © 2016 Flinesoft. All rights reserved.
+//
+
+import Foundation
+
+func swiftExample2Arguments() {
+    _ = NSLocalizedString("test", comment: "test comment")
+}

--- a/Tests/Assets/Multiple Arguments Code/3 Arguments/SwiftExample3Arguments.swift
+++ b/Tests/Assets/Multiple Arguments Code/3 Arguments/SwiftExample3Arguments.swift
@@ -1,0 +1,13 @@
+//
+//  SwiftExample3Arguments.swift
+//  BartyCrouch
+//
+//  Created by Fyodor Volchyok on 12/9/16.
+//  Copyright © 2016 Flinesoft. All rights reserved.
+//
+
+import Foundation
+
+func swiftExample3Arguments() {
+    _ = NSLocalizedString("test", value: "test value", comment: "test comment")
+}

--- a/Tests/Assets/Multiple Arguments Code/4 Arguments/SwiftExample4Arguments.swift
+++ b/Tests/Assets/Multiple Arguments Code/4 Arguments/SwiftExample4Arguments.swift
@@ -1,0 +1,13 @@
+//
+//  SwiftExample4Arguments.swift
+//  BartyCrouch
+//
+//  Created by Fyodor Volchyok on 12/9/16.
+//  Copyright © 2016 Flinesoft. All rights reserved.
+//
+
+import Foundation
+
+func swiftExample4Arguments() {
+    _ = NSLocalizedString("test", tableName: "Localizable", value: "test value", comment: "test comment")
+}

--- a/Tests/Code/CommandLineParserTests.swift
+++ b/Tests/Code/CommandLineParserTests.swift
@@ -15,7 +15,7 @@ class CommandLineParserTests: XCTestCase {
     func testIfCommentCommandIsAdded() {
         CommandLineParser(arguments: ["bartycrouch", "code", "-p", ".", "-l", ".", "--override-comments"]).parse { commonOptions, subCommandOptions in
             switch subCommandOptions {
-            case let .CodeOptions(_, _, _, overrideComments):
+            case let .CodeOptions(_, _, _, overrideComments, _):
                 XCTAssertTrue(overrideComments.value)
             default:
                 XCTAssertTrue(false)
@@ -23,7 +23,7 @@ class CommandLineParserTests: XCTestCase {
         }
         CommandLineParser(arguments: ["bartycrouch", "code", "-p", ".", "-l", ".", "-c"]).parse { commonOptions, subCommandOptions in
             switch subCommandOptions {
-            case let .CodeOptions(_, _, _, overrideComments):
+            case let .CodeOptions(_, _, _, overrideComments, _):
                 XCTAssertTrue(overrideComments.value)
             default:
                 XCTAssertTrue(false)
@@ -34,7 +34,7 @@ class CommandLineParserTests: XCTestCase {
     func testIfCommentCommandIsNotAdded() {
         CommandLineParser(arguments: ["bartycrouch", "translate", "-p", ".", "-i", "no", "-s", "abc", "-l", ".", "--override-comments"]).parse { commonOptions, subCommandOptions in
             switch subCommandOptions {
-            case let .CodeOptions(_, _, _, overrideComments):
+            case let .CodeOptions(_, _, _, overrideComments, _):
                 XCTAssertTrue(!overrideComments.value)
             default:
                 XCTAssertTrue(true)
@@ -42,7 +42,7 @@ class CommandLineParserTests: XCTestCase {
         }
         CommandLineParser(arguments: ["bartycrouch", "translate", "-p", ".", "-i", "no", "-s", "abc", "-l", ".", "-c"]).parse { commonOptions, subCommandOptions in
             switch subCommandOptions {
-            case let .CodeOptions(_, _, _, overrideComments):
+            case let .CodeOptions(_, _, _, overrideComments, _):
                 XCTAssertTrue(!overrideComments.value)
             default:
                 XCTAssertTrue(true)
@@ -50,7 +50,7 @@ class CommandLineParserTests: XCTestCase {
         }
         CommandLineParser(arguments: ["bartycrouch", "interfaces", "-p", ".", "-i", "no", "--override-comments"]).parse { commonOptions, subCommandOptions in
             switch subCommandOptions {
-            case let .CodeOptions(_, _, _, overrideComments):
+            case let .CodeOptions(_, _, _, overrideComments, _):
                 XCTAssertTrue(!overrideComments.value)
             default:
                 XCTAssertTrue(true)
@@ -58,7 +58,7 @@ class CommandLineParserTests: XCTestCase {
         }
         CommandLineParser(arguments: ["bartycrouch", "interfaces", "-p", ".", "-c"]).parse { commonOptions, subCommandOptions in
             switch subCommandOptions {
-            case let .CodeOptions(_, _, _, overrideComments):
+            case let .CodeOptions(_, _, _, overrideComments, _):
                 XCTAssertTrue(!overrideComments.value)
             default:
                 XCTAssertTrue(true)
@@ -66,7 +66,7 @@ class CommandLineParserTests: XCTestCase {
         }
         CommandLineParser(arguments: ["bartycrouch", "code", "-p", ".", "-l", "."]).parse { commonOptions, subCommandOptions in
             switch subCommandOptions {
-            case let .CodeOptions(_, _, _, overrideComments):
+            case let .CodeOptions(_, _, _, overrideComments, _):
                 XCTAssertTrue(!overrideComments.value)
             default:
                 XCTAssertTrue(true)

--- a/Tests/Code/ExtractLocStringsCommanderTests.swift
+++ b/Tests/Code/ExtractLocStringsCommanderTests.swift
@@ -1,0 +1,80 @@
+//
+//  ExtractLocStringsCommanderTests.swift
+//  BartyCrouch
+//
+//  Created by Fyodor Volchyok on 12/9/16.
+//  Copyright © 2016 Flinesoft. All rights reserved.
+//
+
+import XCTest
+
+@testable import BartyCrouch
+
+class ExtractLocStringsCommanderTests: XCTestCase {
+    
+    let baseMultipleArgumentTestCodeDirectory = "\(BASE_DIR)/Tests/Assets/Multiple Arguments Code"
+    
+    override func tearDown() {
+        removeLocalizableStringsFilesRecursively(in: URL(fileURLWithPath: baseMultipleArgumentTestCodeDirectory))
+    }
+    
+    func test2Arguments() {
+        assert(
+            ExtractLocStringsCommander.sharedInstance,
+            takesCodeIn: "\(baseMultipleArgumentTestCodeDirectory)/2 Arguments",
+            producesResult: [
+                "/* test comment */",
+                "\"test\" = \"test\";",
+                "",
+                ""
+            ])
+    }
+    
+    func test3ArgumentsValue() {
+        assert(
+            ExtractLocStringsCommander.sharedInstance,
+            takesCodeIn: "\(baseMultipleArgumentTestCodeDirectory)/3 Arguments",
+            producesResult: [
+                "/* test comment */",
+                "\"test\" = \"test value\";",
+                "",
+                ""
+            ])
+    }
+    
+    func test4ArgumentsBundleValue() {
+        assert(
+            ExtractLocStringsCommander.sharedInstance,
+            takesCodeIn: "\(baseMultipleArgumentTestCodeDirectory)/4 Arguments",
+            producesResult: [
+                "/* test comment */",
+                "\"test\" = \"test value\";",
+                "",
+                ""
+            ])
+    }
+
+    func assert(_ codeCommander: CodeCommander, takesCodeIn directory: String, producesResult expectedLocalizableStringFileContentLines: [String]) {
+        let exportSuccess = codeCommander.export(stringsFilesToPath: directory
+            , fromCodeInDirectoryPath: directory)
+        XCTAssertTrue(exportSuccess)
+        
+        do {
+            let contentsOfStringsFile = try String(contentsOfFile: directory + "/Localizable.strings")
+            let linesInStringsFile = contentsOfStringsFile.components(separatedBy: CharacterSet.newlines)
+            XCTAssertEqual(linesInStringsFile, expectedLocalizableStringFileContentLines)
+        } catch {
+            XCTFail()
+        }
+    }
+    
+    func removeLocalizableStringsFilesRecursively(in directory: URL) {
+        let enumerator = FileManager.default.enumerator(at: directory, includingPropertiesForKeys: [], options: [], errorHandler: nil)!
+        while case let file as URL = enumerator.nextObject() {
+            if file.pathExtension == "strings" {
+                try? FileManager.default.removeItem(at: file)
+            }
+        }
+    }
+    
+}


### PR DESCRIPTION
extractLocString replaces genstrings and fixes error when NSLocalizedString with more than 2 parameters doesn't appear in resulting .string file.