### PR TITLE
Allow passing a custom function via -f / --custom_function

### DIFF
--- a/BartyCrouch.xcodeproj/project.pbxproj
+++ b/BartyCrouch.xcodeproj/project.pbxproj
@@ -72,7 +72,7 @@
 		A1FF9DA21D9324F900D5E85E /* Option.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FF9D9D1D9324F900D5E85E /* Option.swift */; };
 		A1FF9DA31D9324F900D5E85E /* StringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FF9D9E1D9324F900D5E85E /* StringExtensions.swift */; };
 		A1FF9DA41D9324F900D5E85E /* StringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FF9D9E1D9324F900D5E85E /* StringExtensions.swift */; };
-		E4EDD5ED1E314F080010D878 /* BartyCrouchFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 82CDE27F1C6ABF3A00055FE6 /* BartyCrouchFramework.framework */; };
+		E4EDD5ED1E314F080010D878 /* BartyCrouchKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 82CDE27F1C6ABF3A00055FE6 /* BartyCrouchKit.framework */; };
 		E78B1E141DFAB33200C7C290 /* ExtractLocStringsCommander.swift in Sources */ = {isa = PBXBuildFile; fileRef = E78B1E131DFAB33200C7C290 /* ExtractLocStringsCommander.swift */; };
 		E78B1E151DFAB33900C7C290 /* ExtractLocStringsCommander.swift in Sources */ = {isa = PBXBuildFile; fileRef = E78B1E131DFAB33200C7C290 /* ExtractLocStringsCommander.swift */; };
 		E78B1E171DFABA5500C7C290 /* CodeCommander.swift in Sources */ = {isa = PBXBuildFile; fileRef = E78B1E161DFABA5500C7C290 /* CodeCommander.swift */; };
@@ -150,7 +150,7 @@
 		82CDE26E1C6ABD8800055FE6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		82CDE2731C6ABE5C00055FE6 /* bartycrouch */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = bartycrouch; sourceTree = BUILT_PRODUCTS_DIR; };
 		82CDE2751C6ABE5D00055FE6 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
-		82CDE27F1C6ABF3A00055FE6 /* BartyCrouchFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BartyCrouchFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		82CDE27F1C6ABF3A00055FE6 /* BartyCrouchKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BartyCrouchKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		82CDE2881C6ABF3A00055FE6 /* BartyCrouchTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BartyCrouchTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		82CDE2DF1C6BF35500055FE6 /* StringsFileUpdater.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringsFileUpdater.swift; sourceTree = "<group>"; };
 		82CDE2EA1C6BF9D900055FE6 /* IBToolCommander.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IBToolCommander.swift; sourceTree = "<group>"; };
@@ -214,7 +214,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E4EDD5ED1E314F080010D878 /* BartyCrouchFramework.framework in Frameworks */,
+				E4EDD5ED1E314F080010D878 /* BartyCrouchKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -329,7 +329,7 @@
 			isa = PBXGroup;
 			children = (
 				82CDE2731C6ABE5C00055FE6 /* bartycrouch */,
-				82CDE27F1C6ABF3A00055FE6 /* BartyCrouchFramework.framework */,
+				82CDE27F1C6ABF3A00055FE6 /* BartyCrouchKit.framework */,
 				82CDE2881C6ABF3A00055FE6 /* BartyCrouchTests.xctest */,
 			);
 			name = Products;
@@ -671,9 +671,9 @@
 			productReference = 82CDE2731C6ABE5C00055FE6 /* bartycrouch */;
 			productType = "com.apple.product-type.tool";
 		};
-		82CDE27E1C6ABF3A00055FE6 /* BartyCrouch */ = {
+		82CDE27E1C6ABF3A00055FE6 /* BartyCrouchKit */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 82CDE2901C6ABF3A00055FE6 /* Build configuration list for PBXNativeTarget "BartyCrouch" */;
+			buildConfigurationList = 82CDE2901C6ABF3A00055FE6 /* Build configuration list for PBXNativeTarget "BartyCrouchKit" */;
 			buildPhases = (
 				82CDE27A1C6ABF3A00055FE6 /* Sources */,
 				82CDE27B1C6ABF3A00055FE6 /* Frameworks */,
@@ -685,9 +685,9 @@
 			);
 			dependencies = (
 			);
-			name = BartyCrouch;
+			name = BartyCrouchKit;
 			productName = BartyCrouch;
-			productReference = 82CDE27F1C6ABF3A00055FE6 /* BartyCrouchFramework.framework */;
+			productReference = 82CDE27F1C6ABF3A00055FE6 /* BartyCrouchKit.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		82CDE2871C6ABF3A00055FE6 /* BartyCrouchTests */ = {
@@ -747,7 +747,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				82CDE27E1C6ABF3A00055FE6 /* BartyCrouch */,
+				82CDE27E1C6ABF3A00055FE6 /* BartyCrouchKit */,
 				82CDE2871C6ABF3A00055FE6 /* BartyCrouchTests */,
 				82CDE2721C6ABE5C00055FE6 /* BartyCrouch CLI */,
 			);
@@ -886,7 +886,7 @@
 /* Begin PBXTargetDependency section */
 		82CDE28B1C6ABF3A00055FE6 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 82CDE27E1C6ABF3A00055FE6 /* BartyCrouch */;
+			target = 82CDE27E1C6ABF3A00055FE6 /* BartyCrouchKit */;
 			targetProxy = 82CDE28A1C6ABF3A00055FE6 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
@@ -1086,7 +1086,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.flinesoft.BartyCrouch;
-				PRODUCT_NAME = BartyCrouchFramework;
+				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -1111,7 +1111,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.flinesoft.BartyCrouch;
-				PRODUCT_NAME = BartyCrouchFramework;
+				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 3.0;
@@ -1176,7 +1176,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		82CDE2901C6ABF3A00055FE6 /* Build configuration list for PBXNativeTarget "BartyCrouch" */ = {
+		82CDE2901C6ABF3A00055FE6 /* Build configuration list for PBXNativeTarget "BartyCrouchKit" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				82CDE2911C6ABF3A00055FE6 /* Debug */,

--- a/BartyCrouch.xcodeproj/project.pbxproj
+++ b/BartyCrouch.xcodeproj/project.pbxproj
@@ -126,7 +126,7 @@
 		82463DF91CD910FD00D28A2C /* GenStringsCommander.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GenStringsCommander.swift; sourceTree = "<group>"; };
 		82463E031CD9164000D28A2C /* SwiftExample1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftExample1.swift; sourceTree = "<group>"; };
 		82463E051CD9180D00D28A2C /* SwiftExample2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftExample2.swift; sourceTree = "<group>"; };
-		82463E0A1CD9197600D28A2C /* GenStringsCommanderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GenStringsCommanderTests.swift; sourceTree = "<group>"; };
+		82463E0A1CD9197600D28A2C /* GenStringsCommanderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = GenStringsCommanderTests.swift; sourceTree = "<group>"; };
 		8249B7C71C70D1CF002F1BB7 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Example.strings; sourceTree = "<group>"; };
 		8249B7C91C70D1D6002F1BB7 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Example.strings; sourceTree = "<group>"; };
 		8249B7CB1C70D1D8002F1BB7 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Example.strings; sourceTree = "<group>"; };
@@ -181,9 +181,15 @@
 		A1FF9D9C1D9324F900D5E85E /* CommandLineKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CommandLineKit.swift; path = Carthage/Checkouts/CommandLine/CommandLineKit/CommandLineKit.swift; sourceTree = SOURCE_ROOT; };
 		A1FF9D9D1D9324F900D5E85E /* Option.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Option.swift; path = Carthage/Checkouts/CommandLine/CommandLineKit/Option.swift; sourceTree = SOURCE_ROOT; };
 		A1FF9D9E1D9324F900D5E85E /* StringExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StringExtensions.swift; path = Carthage/Checkouts/CommandLine/CommandLineKit/StringExtensions.swift; sourceTree = SOURCE_ROOT; };
+		E4EDD5F91E3151BE0010D878 /* SwiftExample2Arguments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftExample2Arguments.swift; sourceTree = "<group>"; };
+		E4EDD5FB1E3151BE0010D878 /* SwiftExample3Arguments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftExample3Arguments.swift; sourceTree = "<group>"; };
+		E4EDD5FD1E3151BE0010D878 /* SwiftExample4Arguments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftExample4Arguments.swift; sourceTree = "<group>"; };
+		E4EDD6061E3156E00010D878 /* SwiftExample2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftExample2.swift; sourceTree = "<group>"; };
+		E4EDD6071E3156E00010D878 /* SwiftExample1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftExample1.swift; sourceTree = "<group>"; };
+		E4EDD6091E3156E00010D878 /* SwiftExample3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftExample3.swift; sourceTree = "<group>"; };
 		E78B1E131DFAB33200C7C290 /* ExtractLocStringsCommander.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtractLocStringsCommander.swift; sourceTree = "<group>"; };
 		E78B1E161DFABA5500C7C290 /* CodeCommander.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CodeCommander.swift; sourceTree = "<group>"; };
-		E7974AF11DFAE9AA00E31754 /* ExtractLocStringsCommanderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtractLocStringsCommanderTests.swift; sourceTree = "<group>"; };
+		E7974AF11DFAE9AA00E31754 /* ExtractLocStringsCommanderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = ExtractLocStringsCommanderTests.swift; sourceTree = "<group>"; };
 		E7974AFA1DFAECA700E31754 /* SwiftExample2Arguments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftExample2Arguments.swift; sourceTree = "<group>"; };
 		E7974AFC1DFAECA700E31754 /* SwiftExample3Arguments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftExample3Arguments.swift; sourceTree = "<group>"; };
 		E7974B001DFAFD2D00E31754 /* SwiftExample4Arguments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftExample4Arguments.swift; sourceTree = "<group>"; };
@@ -390,7 +396,9 @@
 			isa = PBXGroup;
 			children = (
 				E7974AF81DFAECA700E31754 /* Multiple Arguments Code */,
+				E4EDD5F71E3151BE0010D878 /* Multiple Arguments Code Custom Function */,
 				82463E011CD915DB00D28A2C /* Code Files */,
+				E4EDD6041E3156E00010D878 /* Code Files Custom Function */,
 				82CDE2F81C6C0BAA00055FE6 /* Strings Files */,
 				82CDE2FF1C6C0BAA00055FE6 /* Storyboards */,
 			);
@@ -534,6 +542,67 @@
 				A1B73EC31E00ABDE0070D20F /* Info.plist */,
 			);
 			path = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		E4EDD5F71E3151BE0010D878 /* Multiple Arguments Code Custom Function */ = {
+			isa = PBXGroup;
+			children = (
+				E4EDD5F81E3151BE0010D878 /* 2 Arguments */,
+				E4EDD5FA1E3151BE0010D878 /* 3 Arguments */,
+				E4EDD5FC1E3151BE0010D878 /* 4 Arguments */,
+			);
+			path = "Multiple Arguments Code Custom Function";
+			sourceTree = "<group>";
+		};
+		E4EDD5F81E3151BE0010D878 /* 2 Arguments */ = {
+			isa = PBXGroup;
+			children = (
+				E4EDD5F91E3151BE0010D878 /* SwiftExample2Arguments.swift */,
+			);
+			path = "2 Arguments";
+			sourceTree = "<group>";
+		};
+		E4EDD5FA1E3151BE0010D878 /* 3 Arguments */ = {
+			isa = PBXGroup;
+			children = (
+				E4EDD5FB1E3151BE0010D878 /* SwiftExample3Arguments.swift */,
+			);
+			path = "3 Arguments";
+			sourceTree = "<group>";
+		};
+		E4EDD5FC1E3151BE0010D878 /* 4 Arguments */ = {
+			isa = PBXGroup;
+			children = (
+				E4EDD5FD1E3151BE0010D878 /* SwiftExample4Arguments.swift */,
+			);
+			path = "4 Arguments";
+			sourceTree = "<group>";
+		};
+		E4EDD6041E3156E00010D878 /* Code Files Custom Function */ = {
+			isa = PBXGroup;
+			children = (
+				E4EDD6051E3156E00010D878 /* Subfolder */,
+				E4EDD6071E3156E00010D878 /* SwiftExample1.swift */,
+				E4EDD6081E3156E00010D878 /* UnsortedKeys */,
+			);
+			name = "Code Files Custom Function";
+			path = "Tests/Assets/Code Files Custom Function";
+			sourceTree = SOURCE_ROOT;
+		};
+		E4EDD6051E3156E00010D878 /* Subfolder */ = {
+			isa = PBXGroup;
+			children = (
+				E4EDD6061E3156E00010D878 /* SwiftExample2.swift */,
+			);
+			path = Subfolder;
+			sourceTree = "<group>";
+		};
+		E4EDD6081E3156E00010D878 /* UnsortedKeys */ = {
+			isa = PBXGroup;
+			children = (
+				E4EDD6091E3156E00010D878 /* SwiftExample3.swift */,
+			);
+			path = UnsortedKeys;
 			sourceTree = "<group>";
 		};
 		E7974AF81DFAECA700E31754 /* Multiple Arguments Code */ = {

--- a/BartyCrouch.xcodeproj/project.pbxproj
+++ b/BartyCrouch.xcodeproj/project.pbxproj
@@ -31,7 +31,6 @@
 		828ED5361C710C2F00E0E947 /* IBToolCommander.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82CDE2EA1C6BF9D900055FE6 /* IBToolCommander.swift */; };
 		828ED5371C710C3100E0E947 /* StringsFilesSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 821DED391C70CFBB00B8353B /* StringsFilesSearch.swift */; };
 		82CDE2761C6ABE5D00055FE6 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82CDE2751C6ABE5D00055FE6 /* main.swift */; };
-		82CDE2891C6ABF3A00055FE6 /* BartyCrouch.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 82CDE27F1C6ABF3A00055FE6 /* BartyCrouch.framework */; };
 		82CDE2981C6ABFB800055FE6 /* BartyCrouch.h in Headers */ = {isa = PBXBuildFile; fileRef = 82CDE2641C6ABBF500055FE6 /* BartyCrouch.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		82CDE2E01C6BF35500055FE6 /* StringsFileUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82CDE2DF1C6BF35500055FE6 /* StringsFileUpdater.swift */; };
 		82CDE2EB1C6BF9D900055FE6 /* IBToolCommander.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82CDE2EA1C6BF9D900055FE6 /* IBToolCommander.swift */; };
@@ -73,6 +72,7 @@
 		A1FF9DA21D9324F900D5E85E /* Option.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FF9D9D1D9324F900D5E85E /* Option.swift */; };
 		A1FF9DA31D9324F900D5E85E /* StringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FF9D9E1D9324F900D5E85E /* StringExtensions.swift */; };
 		A1FF9DA41D9324F900D5E85E /* StringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FF9D9E1D9324F900D5E85E /* StringExtensions.swift */; };
+		E4EDD5ED1E314F080010D878 /* BartyCrouchFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 82CDE27F1C6ABF3A00055FE6 /* BartyCrouchFramework.framework */; };
 		E78B1E141DFAB33200C7C290 /* ExtractLocStringsCommander.swift in Sources */ = {isa = PBXBuildFile; fileRef = E78B1E131DFAB33200C7C290 /* ExtractLocStringsCommander.swift */; };
 		E78B1E151DFAB33900C7C290 /* ExtractLocStringsCommander.swift in Sources */ = {isa = PBXBuildFile; fileRef = E78B1E131DFAB33200C7C290 /* ExtractLocStringsCommander.swift */; };
 		E78B1E171DFABA5500C7C290 /* CodeCommander.swift in Sources */ = {isa = PBXBuildFile; fileRef = E78B1E161DFABA5500C7C290 /* CodeCommander.swift */; };
@@ -150,7 +150,7 @@
 		82CDE26E1C6ABD8800055FE6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		82CDE2731C6ABE5C00055FE6 /* bartycrouch */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = bartycrouch; sourceTree = BUILT_PRODUCTS_DIR; };
 		82CDE2751C6ABE5D00055FE6 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
-		82CDE27F1C6ABF3A00055FE6 /* BartyCrouch.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BartyCrouch.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		82CDE27F1C6ABF3A00055FE6 /* BartyCrouchFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BartyCrouchFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		82CDE2881C6ABF3A00055FE6 /* BartyCrouchTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BartyCrouchTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		82CDE2DF1C6BF35500055FE6 /* StringsFileUpdater.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringsFileUpdater.swift; sourceTree = "<group>"; };
 		82CDE2EA1C6BF9D900055FE6 /* IBToolCommander.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IBToolCommander.swift; sourceTree = "<group>"; };
@@ -208,7 +208,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				82CDE2891C6ABF3A00055FE6 /* BartyCrouch.framework in Frameworks */,
+				E4EDD5ED1E314F080010D878 /* BartyCrouchFramework.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -323,7 +323,7 @@
 			isa = PBXGroup;
 			children = (
 				82CDE2731C6ABE5C00055FE6 /* bartycrouch */,
-				82CDE27F1C6ABF3A00055FE6 /* BartyCrouch.framework */,
+				82CDE27F1C6ABF3A00055FE6 /* BartyCrouchFramework.framework */,
 				82CDE2881C6ABF3A00055FE6 /* BartyCrouchTests.xctest */,
 			);
 			name = Products;
@@ -618,7 +618,7 @@
 			);
 			name = BartyCrouch;
 			productName = BartyCrouch;
-			productReference = 82CDE27F1C6ABF3A00055FE6 /* BartyCrouch.framework */;
+			productReference = 82CDE27F1C6ABF3A00055FE6 /* BartyCrouchFramework.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		82CDE2871C6ABF3A00055FE6 /* BartyCrouchTests */ = {
@@ -1017,7 +1017,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.flinesoft.BartyCrouch;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = BartyCrouchFramework;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -1042,7 +1042,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.flinesoft.BartyCrouch;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = BartyCrouchFramework;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 3.0;

--- a/BartyCrouch.xcodeproj/project.pbxproj
+++ b/BartyCrouch.xcodeproj/project.pbxproj
@@ -126,7 +126,7 @@
 		82463DF91CD910FD00D28A2C /* GenStringsCommander.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GenStringsCommander.swift; sourceTree = "<group>"; };
 		82463E031CD9164000D28A2C /* SwiftExample1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftExample1.swift; sourceTree = "<group>"; };
 		82463E051CD9180D00D28A2C /* SwiftExample2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftExample2.swift; sourceTree = "<group>"; };
-		82463E0A1CD9197600D28A2C /* GenStringsCommanderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = GenStringsCommanderTests.swift; sourceTree = "<group>"; };
+		82463E0A1CD9197600D28A2C /* GenStringsCommanderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GenStringsCommanderTests.swift; sourceTree = "<group>"; };
 		8249B7C71C70D1CF002F1BB7 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Example.strings; sourceTree = "<group>"; };
 		8249B7C91C70D1D6002F1BB7 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Example.strings; sourceTree = "<group>"; };
 		8249B7CB1C70D1D8002F1BB7 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Example.strings; sourceTree = "<group>"; };
@@ -189,7 +189,7 @@
 		E4EDD6091E3156E00010D878 /* SwiftExample3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftExample3.swift; sourceTree = "<group>"; };
 		E78B1E131DFAB33200C7C290 /* ExtractLocStringsCommander.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtractLocStringsCommander.swift; sourceTree = "<group>"; };
 		E78B1E161DFABA5500C7C290 /* CodeCommander.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CodeCommander.swift; sourceTree = "<group>"; };
-		E7974AF11DFAE9AA00E31754 /* ExtractLocStringsCommanderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = ExtractLocStringsCommanderTests.swift; sourceTree = "<group>"; };
+		E7974AF11DFAE9AA00E31754 /* ExtractLocStringsCommanderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtractLocStringsCommanderTests.swift; sourceTree = "<group>"; };
 		E7974AFA1DFAECA700E31754 /* SwiftExample2Arguments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftExample2Arguments.swift; sourceTree = "<group>"; };
 		E7974AFC1DFAECA700E31754 /* SwiftExample3Arguments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftExample3Arguments.swift; sourceTree = "<group>"; };
 		E7974B001DFAFD2D00E31754 /* SwiftExample4Arguments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftExample4Arguments.swift; sourceTree = "<group>"; };

--- a/BartyCrouch.xcodeproj/xcshareddata/xcschemes/BartyCrouch.xcscheme
+++ b/BartyCrouch.xcodeproj/xcshareddata/xcschemes/BartyCrouch.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "82CDE27E1C6ABF3A00055FE6"
-               BuildableName = "BartyCrouch.framework"
+               BuildableName = "BartyCrouchFramework.framework"
                BlueprintName = "BartyCrouch"
                ReferencedContainer = "container:BartyCrouch.xcodeproj">
             </BuildableReference>
@@ -43,7 +43,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "82CDE27E1C6ABF3A00055FE6"
-            BuildableName = "BartyCrouch.framework"
+            BuildableName = "BartyCrouchFramework.framework"
             BlueprintName = "BartyCrouch"
             ReferencedContainer = "container:BartyCrouch.xcodeproj">
          </BuildableReference>
@@ -65,7 +65,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "82CDE27E1C6ABF3A00055FE6"
-            BuildableName = "BartyCrouch.framework"
+            BuildableName = "BartyCrouchFramework.framework"
             BlueprintName = "BartyCrouch"
             ReferencedContainer = "container:BartyCrouch.xcodeproj">
          </BuildableReference>
@@ -83,7 +83,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "82CDE27E1C6ABF3A00055FE6"
-            BuildableName = "BartyCrouch.framework"
+            BuildableName = "BartyCrouchFramework.framework"
             BlueprintName = "BartyCrouch"
             ReferencedContainer = "container:BartyCrouch.xcodeproj">
          </BuildableReference>

--- a/BartyCrouch.xcodeproj/xcshareddata/xcschemes/BartyCrouch.xcscheme
+++ b/BartyCrouch.xcodeproj/xcshareddata/xcschemes/BartyCrouch.xcscheme
@@ -15,8 +15,8 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "82CDE27E1C6ABF3A00055FE6"
-               BuildableName = "BartyCrouchFramework.framework"
-               BlueprintName = "BartyCrouch"
+               BuildableName = "BartyCrouchKit.framework"
+               BlueprintName = "BartyCrouchKit"
                ReferencedContainer = "container:BartyCrouch.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -43,8 +43,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "82CDE27E1C6ABF3A00055FE6"
-            BuildableName = "BartyCrouchFramework.framework"
-            BlueprintName = "BartyCrouch"
+            BuildableName = "BartyCrouchKit.framework"
+            BlueprintName = "BartyCrouchKit"
             ReferencedContainer = "container:BartyCrouch.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -65,8 +65,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "82CDE27E1C6ABF3A00055FE6"
-            BuildableName = "BartyCrouchFramework.framework"
-            BlueprintName = "BartyCrouch"
+            BuildableName = "BartyCrouchKit.framework"
+            BlueprintName = "BartyCrouchKit"
             ReferencedContainer = "container:BartyCrouch.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -83,8 +83,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "82CDE27E1C6ABF3A00055FE6"
-            BuildableName = "BartyCrouchFramework.framework"
-            BlueprintName = "BartyCrouch"
+            BuildableName = "BartyCrouchKit.framework"
+            BlueprintName = "BartyCrouchKit"
             ReferencedContainer = "container:BartyCrouch.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ $ bartycrouch code -p "/path/to/code/files" -l "/path/to/localizables" -s
 
 #### Custom Function (aka `-f`, `--custom-function`) <small>*optional*</small>
 
-If you use a **custom function** in your code to localize your Strings (instead of `NSLocalizedString`) you can specify it using this option. Please refer to [the official docs](https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/LoadingResources/Strings/Strings.html#//apple_ref/doc/uid/10000051i-CH6-SW11) to learn more about custom functions. BartyCrouch uses `genstrings` under the hoods to make this work, so you need to make sure your custom function follows the requirements of `genstrings`.
+If you use a **custom function** in your code to localize your Strings (instead of `NSLocalizedString`) you can specify it using this option. BartyCrouch passes this along to the `genstrings`/`extractLocStrings` tools. So you need to make sure your custom function follows the requirements of `genstrings`/`extractLocStrings`.
 
 ```shell
 $ bartycrouch code -p "/path/to/code/files" -l "/path/to/Localizables" -f "YourCustomFunction"

--- a/README.md
+++ b/README.md
@@ -79,9 +79,6 @@ $ bartycrouch interfaces -p "/absolute/path/to/project"
 # Updates `Localizable.strings` files with new keys searching your code for `NSLocalizedString`
 $ bartycrouch code -p "/path/to/code/directory" -l "/directory/containing/all/Localizables" -a
 
-# Updates `Localizable.strings` files with new keys searching your code for `YourCustomFunction`. Useful when you are using something else than `NSLocalizedString`
-$ bartycrouch code -p "/path/to/code/directory" -l "/directory/containing/all/Localizables" -a -c "YourCustomFunction"
-
 # Machine-translate all empty localization values using English as source language
 $ bartycrouch translate -p "/path/to/project" -l en -i "<API_ID>" -s "<API_SECRET>"
 ```
@@ -188,6 +185,7 @@ Here's an overview of all options available for the sub command `code`:
 - `override-comments`
 - `extract-loc-strings`
 - `sort-by-keys`
+- `custom-function`
 
 #### Localizable (aka `-l`, `--localizable`) <small>*required*</small>
 
@@ -251,12 +249,12 @@ Example:
 $ bartycrouch code -p "/path/to/code/files" -l "/path/to/localizables" -s
 ```
 
-#### Custom Function (aka `-c`, `--customFunction`) <small>*optional*</small>
+#### Custom Function (aka `-f`, `--custom-function`) <small>*optional*</small>
 
-If you use a custom function(macro) in your code to localize the strings instead of NSLocalizedString, you may specify it using this option. BartyCrouch will parse the code for the name you give instead of the default NSLocalizedString. Your functions must use the naming and formatting conventions used by the Foundation macros. The parameters for your functions must match the parameters for the corresponding macros exactly. The parsing is done using "genstrings" tool. You may see more in <a href="https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/LoadingResources/Strings/Strings.html">Apple's documentation</a> about it. Look into "Searching for Custom Functions With genstrings" section.
+If you use a **custom function** in your code to localize your Strings (instead of `NSLocalizedString`) you can specify it using this option. Please refer to [the official docs](https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/LoadingResources/Strings/Strings.html#//apple_ref/doc/uid/10000051i-CH6-SW11) to learn more about custom functions. BartyCrouch uses `genstrings` under the hoods to make this work, so you need to make sure your custom function follows the requirements of `genstrings`.
 
 ```shell
-$ bartycrouch code -p "/path/to/code/files" -l "/path/to/Localizables" -c "YourCustomFunction"
+$ bartycrouch code -p "/path/to/code/files" -l "/path/to/Localizables" -f "YourCustomFunction"
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ $ bartycrouch interfaces -p "/absolute/path/to/project"
 # Updates `Localizable.strings` files with new keys searching your code for `NSLocalizedString`
 $ bartycrouch code -p "/path/to/code/directory" -l "/directory/containing/all/Localizables" -a
 
+# Updates `Localizable.strings` files with new keys searching your code for `YourCustomFunction`. Useful when you are using something else than `NSLocalizedString`
+$ bartycrouch code -p "/path/to/code/directory" -l "/directory/containing/all/Localizables" -a -c "YourCustomFunction"
+
 # Machine-translate all empty localization values using English as source language
 $ bartycrouch translate -p "/path/to/project" -l en -i "<API_ID>" -s "<API_SECRET>"
 ```
@@ -246,6 +249,14 @@ Example:
 
 ```shell
 $ bartycrouch code -p "/path/to/code/files" -l "/path/to/localizables" -s
+```
+
+#### Custom Function (aka `-c`, `--customFunction`) <small>*optional*</small>
+
+If you use a custom function(macro) in your code to localize the strings instead of NSLocalizedString, you may specify it using this option. BartyCrouch will parse the code for the name you give instead of the default NSLocalizedString. Your functions must use the naming and formatting conventions used by the Foundation macros. The parameters for your functions must match the parameters for the corresponding macros exactly. The parsing is done using "genstrings" tool. You may see more in <a href="https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/LoadingResources/Strings/Strings.html">Apple's documentation</a> about it. Look into "Searching for Custom Functions With genstrings" section.
+
+```shell
+$ bartycrouch code -p "/path/to/code/files" -l "/path/to/Localizables" -c "YourCustomFunction"
 ```
 
 ---

--- a/Sources/Code/CodeCommander.swift
+++ b/Sources/Code/CodeCommander.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 protocol CodeCommander {
-    func export(stringsFilesToPath stringsFilePath: String, fromCodeInDirectoryPath codeDirectoryPath: String) -> Bool
+    func export(stringsFilesToPath stringsFilePath: String, fromCodeInDirectoryPath codeDirectoryPath: String, customFunction: String?) -> Bool
 }
 
 extension CodeCommander {

--- a/Sources/Code/CommandLineActor.swift
+++ b/Sources/Code/CommandLineActor.swift
@@ -28,14 +28,15 @@ public class CommandLineActor {
         let verbose = commonOptions.verbose.value
 
         switch subCommandOptions {
-        case let .codeOptions(localizableOption, defaultToKeysOption, additiveOption, overrideComments, useExtractLocStrings, sortByKeys):
+        case let .codeOptions(localizableOption, defaultToKeysOption, additiveOption, overrideComments, useExtractLocStrings, sortByKeys, customFunction):
             guard let localizable = localizableOption.value else {
                 printError("Localizable option `-l` is missing.")
                 exit(EX_USAGE)
             }
 
             self.actOnCode(path: path, override: override, verbose: verbose, localizable: localizable, defaultToKeys: defaultToKeysOption.value, additive: additiveOption.value,
-                           overrideComments: overrideComments.value, useExtractLocStrings: useExtractLocStrings.value, sortByKeys: sortByKeys.value)
+                           overrideComments: overrideComments.value, useExtractLocStrings: useExtractLocStrings.value, sortByKeys: sortByKeys.value,
+                           customFunction: customFunction.value)
 
         case let .interfacesOptions(defaultToBaseOption):
             self.actOnInterfaces(path: path, override: override, verbose: verbose, defaultToBase: defaultToBaseOption.value)
@@ -61,7 +62,7 @@ public class CommandLineActor {
     }
 
     private func actOnCode(path: String, override: Bool, verbose: Bool, localizable: String, defaultToKeys: Bool, additive: Bool,
-                           overrideComments: Bool, useExtractLocStrings: Bool, sortByKeys: Bool) {
+                           overrideComments: Bool, useExtractLocStrings: Bool, sortByKeys: Bool, customFunction: String?) {
         let allLocalizableStringsFilePaths = StringsFilesSearch.shared.findAllStringsFiles(within: localizable, withFileName: "Localizable")
 
         guard !allLocalizableStringsFilePaths.isEmpty else {
@@ -77,7 +78,8 @@ public class CommandLineActor {
         }
 
         self.incrementalCodeUpdate(inputDirectoryPath: path, allLocalizableStringsFilePaths, override: override, verbose: verbose, defaultToKeys: defaultToKeys,
-                                   additive: additive, overrideComments: overrideComments, useExtractLocStrings: useExtractLocStrings, sortByKeys: sortByKeys)
+                                   additive: additive, overrideComments: overrideComments, useExtractLocStrings: useExtractLocStrings, sortByKeys: sortByKeys,
+                                   customFunction: customFunction)
     }
 
     private func actOnInterfaces(path: String, override: Bool, verbose: Bool, defaultToBase: Bool) {
@@ -135,7 +137,7 @@ public class CommandLineActor {
     }
 
     private func incrementalCodeUpdate(inputDirectoryPath: String, _ outputStringsFilePaths: [String], override: Bool, verbose: Bool, defaultToKeys: Bool,
-                                       additive: Bool, overrideComments: Bool, useExtractLocStrings: Bool, sortByKeys: Bool) {
+                                       additive: Bool, overrideComments: Bool, useExtractLocStrings: Bool, sortByKeys: Bool, customFunction: String?) {
         let extractedStringsFileDirectory = inputDirectoryPath + "/tmpstrings/"
 
         do {
@@ -147,7 +149,7 @@ public class CommandLineActor {
 
         let codeCommander: CodeCommander = useExtractLocStrings ? ExtractLocStringsCommander.shared : GenStringsCommander.shared
 
-        guard codeCommander.export(stringsFilesToPath: extractedStringsFileDirectory, fromCodeInDirectoryPath: inputDirectoryPath) else {
+        guard codeCommander.export(stringsFilesToPath: extractedStringsFileDirectory, fromCodeInDirectoryPath: inputDirectoryPath, customFunction: customFunction) else {
             printError("Could not extract strings from Code in directory '\(inputDirectoryPath)'.")
             exit(EX_UNAVAILABLE)
         }

--- a/Sources/Code/CommandLineParser.swift
+++ b/Sources/Code/CommandLineParser.swift
@@ -27,7 +27,7 @@ public class CommandLineParser {
     public enum SubCommandOptions {
         case codeOptions(
             localizable: StringOption, defaultToKeys: BoolOption, additive: BoolOption, overrideComments: BoolOption,
-            useExtractLocStrings: BoolOption, sortByKeys: BoolOption
+            useExtractLocStrings: BoolOption, sortByKeys: BoolOption, customFunction: StringOption
         )
         case interfacesOptions(defaultToBase: BoolOption)
         case translateOptions(id: StringOption, secret: StringOption, locale: StringOption)
@@ -122,12 +122,21 @@ public class CommandLineParser {
         let overrideComments = BoolOption(shortFlag: "c", longFlag: "override-comments", required: false, helpMessage: "Overrides existing translation comments.")
         let useExtractLocStrings = BoolOption(shortFlag: "e", longFlag: "extract-loc-strings", required: false, helpMessage: "Uses extractLocStrings instead of genstrings")
         let sortByKeys = BoolOption(shortFlag: "s", longFlag: "sort-by-keys", required: false, helpMessage: "Sorts the entries in the resulting Strings file by keys.")
-
+        let customFunction = StringOption(shortFlag: "f",
+                                          longFlag: "custom-function",
+                                          required: false,
+                                          helpMessage: "Specifies a custom function to be parsed by genstrings via '-s' option."
+        )
         let commonOptions: CommonOptions = (path: path, override: override, verbose: verbose)
-        let subCommandOptions = SubCommandOptions.codeOptions(localizable: localizable, defaultToKeys: defaultToKeys, additive: additive, overrideComments: overrideComments,
-                                                              useExtractLocStrings: useExtractLocStrings, sortByKeys: sortByKeys)
+        let subCommandOptions = SubCommandOptions.codeOptions(localizable: localizable,
+                                                              defaultToKeys: defaultToKeys,
+                                                              additive: additive,
+                                                              overrideComments: overrideComments,
+                                                              useExtractLocStrings: useExtractLocStrings,
+                                                              sortByKeys: sortByKeys,
+                                                              customFunction: customFunction)
 
-        commandLine.addOptions(path, localizable, override, verbose, defaultToKeys, additive, overrideComments, useExtractLocStrings, sortByKeys)
+        commandLine.addOptions(path, localizable, override, verbose, defaultToKeys, additive, overrideComments, useExtractLocStrings, sortByKeys, customFunction)
         return (commandLine, commonOptions, subCommandOptions)
     }
 

--- a/Sources/Code/ExtractLocStringsCommander.swift
+++ b/Sources/Code/ExtractLocStringsCommander.swift
@@ -17,9 +17,11 @@ public class ExtractLocStringsCommander: CodeCommander {
 
     // MARK: - Instance Methods
 
-    public func export(stringsFilesToPath stringsFilePath: String, fromCodeInDirectoryPath codeDirectoryPath: String) -> Bool {
+    public func export(stringsFilesToPath stringsFilePath: String, fromCodeInDirectoryPath codeDirectoryPath: String, customFunction: String?) -> Bool {
         let findFilesResult = findFiles(in: codeDirectoryPath)
-        let exportFileResult = Commander.shared.run(command: "/usr/bin/xcrun", arguments: ["extractLocStrings"] + findFilesResult.outputs + ["-o", stringsFilePath])
+        let customFunctionArgs = customFunction != nil ? ["-s", "\(customFunction!)"] : []
+        let exportFileResult = Commander.shared.run(command: "/usr/bin/xcrun",
+                                                    arguments: ["extractLocStrings"] + findFilesResult.outputs + ["-o", stringsFilePath] + customFunctionArgs)
         return findFilesResult.exitCode == 0 && exportFileResult.exitCode == 0
     }
 }

--- a/Sources/Code/GenStringsCommander.swift
+++ b/Sources/Code/GenStringsCommander.swift
@@ -17,9 +17,10 @@ public class GenStringsCommander: CodeCommander {
 
     // MARK: - Instance Methods
 
-    public func export(stringsFilesToPath stringsFilePath: String, fromCodeInDirectoryPath codeDirectoryPath: String) -> Bool {
+    public func export(stringsFilesToPath stringsFilePath: String, fromCodeInDirectoryPath codeDirectoryPath: String, customFunction: String?) -> Bool {
         let findFilesResult = findFiles(in: codeDirectoryPath)
-        let exportFileResult = Commander.shared.run(command: "/usr/bin/genstrings", arguments: findFilesResult.outputs + ["-o", stringsFilePath])
+        let customFunctionArgs = customFunction != nil ? ["-s", "\(customFunction!)"] : []
+        let exportFileResult = Commander.shared.run(command: "/usr/bin/genstrings", arguments: findFilesResult.outputs + ["-o", stringsFilePath] + customFunctionArgs)
         return findFilesResult.exitCode == 0 && exportFileResult.exitCode == 0
     }
 }

--- a/Tests/Assets/Code Files Custom Function/Subfolder/SwiftExample2.swift
+++ b/Tests/Assets/Code Files Custom Function/Subfolder/SwiftExample2.swift
@@ -1,0 +1,17 @@
+//
+//  SwiftExample2.swift
+//  BartyCrouch
+//
+//  Created by Cihat Gündüz on 03.05.16.
+//  Copyright © 2016 Flinesoft. All rights reserved.
+//
+
+import Foundation
+
+class SwiftExample2 {
+    func exampleFunction2() {
+        BCLocalizedString("TestKey2", comment: "Comment for TestKey1")
+        String(format: BCLocalizedString("%010d and %03.f", comment: ""), 25, 89.5)
+        String.localizableStringWithFormat(BCLocalizedString("%d ignore(s)", comment: "Ignoring stringsdict key #bc-ignore!"), 25)
+    }
+}

--- a/Tests/Assets/Code Files Custom Function/SwiftExample1.swift
+++ b/Tests/Assets/Code Files Custom Function/SwiftExample1.swift
@@ -1,0 +1,21 @@
+//
+//  SwiftExample1.swift
+//  BartyCrouch
+//
+//  Created by Cihat Gündüz on 03.05.16.
+//  Copyright © 2016 Flinesoft. All rights reserved.
+//
+
+import Foundation
+
+class SwiftExample1 {
+    func exampleFunction1() {
+        BCLocalizedString("TestKey1", comment: "Comment for TestKey1")
+        String(format: BCLocalizedString("%@ and %.2f", comment: ""), "SomeString", 25.7528938)
+
+        let s1 = BCLocalizedString("test.multiline_comment", comment: "test comment 1")
+        let s2 = BCLocalizedString("test.multiline_comment", comment: "test comment 2")
+
+        BCLocalizedString("test.brackets_comment", comment: "(test comment with brackets)")
+    }
+}

--- a/Tests/Assets/Code Files Custom Function/UnsortedKeys/SwiftExample3.swift
+++ b/Tests/Assets/Code Files Custom Function/UnsortedKeys/SwiftExample3.swift
@@ -1,0 +1,15 @@
+//
+//  SwiftExample3.swift
+//  BartyCrouch
+//
+//  Created by Cihat Gündüz on 27.08.16.
+//  Copyright © 2016 Flinesoft. All rights reserved.
+//
+
+import Foundation
+
+class SwiftExample3 {
+    func exampleFunction1() {
+        BCLocalizedString("ccc", comment: "")
+    }
+}

--- a/Tests/Assets/Multiple Arguments Code Custom Function/2 Arguments/SwiftExample2Arguments.swift
+++ b/Tests/Assets/Multiple Arguments Code Custom Function/2 Arguments/SwiftExample2Arguments.swift
@@ -1,0 +1,13 @@
+//
+//  SwiftExample2Arguments.swift
+//  BartyCrouch
+//
+//  Created by Fyodor Volchyok on 12/9/16.
+//  Copyright © 2016 Flinesoft. All rights reserved.
+//
+
+import Foundation
+
+func swiftExample2Arguments() {
+    _ = BCLocalizedString("test", comment: "test comment")
+}

--- a/Tests/Assets/Multiple Arguments Code Custom Function/3 Arguments/SwiftExample3Arguments.swift
+++ b/Tests/Assets/Multiple Arguments Code Custom Function/3 Arguments/SwiftExample3Arguments.swift
@@ -1,0 +1,13 @@
+//
+//  SwiftExample3Arguments.swift
+//  BartyCrouch
+//
+//  Created by Fyodor Volchyok on 12/9/16.
+//  Copyright © 2016 Flinesoft. All rights reserved.
+//
+
+import Foundation
+
+func swiftExample3Arguments() {
+    _ = BCLocalizedString("test", value: "test value", comment: "test comment")
+}

--- a/Tests/Assets/Multiple Arguments Code Custom Function/4 Arguments/SwiftExample4Arguments.swift
+++ b/Tests/Assets/Multiple Arguments Code Custom Function/4 Arguments/SwiftExample4Arguments.swift
@@ -1,0 +1,13 @@
+//
+//  SwiftExample4Arguments.swift
+//  BartyCrouch
+//
+//  Created by Fyodor Volchyok on 12/9/16.
+//  Copyright © 2016 Flinesoft. All rights reserved.
+//
+
+import Foundation
+
+func swiftExample4Arguments() {
+    _ = BCLocalizedString("test", tableName: "Localizable", value: "test value", comment: "test comment")
+}

--- a/Tests/Code/CommandLineActorTests.swift
+++ b/Tests/Code/CommandLineActorTests.swift
@@ -8,7 +8,7 @@
 
 import XCTest
 
-@testable import BartyCrouchFramework
+@testable import BartyCrouchKit
 
 // swiftlint:disable force_try
 

--- a/Tests/Code/CommandLineActorTests.swift
+++ b/Tests/Code/CommandLineActorTests.swift
@@ -8,7 +8,7 @@
 
 import XCTest
 
-@testable import BartyCrouch
+@testable import BartyCrouchFramework
 
 // swiftlint:disable force_try
 

--- a/Tests/Code/CommandLineParserTests.swift
+++ b/Tests/Code/CommandLineParserTests.swift
@@ -8,7 +8,7 @@
 
 import XCTest
 
-@testable import BartyCrouch
+@testable import BartyCrouchFramework
 
 class CommandLineParserTests: XCTestCase {
     func testIfCommentCommandIsAdded() {

--- a/Tests/Code/CommandLineParserTests.swift
+++ b/Tests/Code/CommandLineParserTests.swift
@@ -14,7 +14,7 @@ class CommandLineParserTests: XCTestCase {
     func testIfCommentCommandIsAdded() {
         CommandLineParser(arguments: ["bartycrouch", "code", "-p", ".", "-l", ".", "--override-comments"]).parse { commonOptions, subCommandOptions in
             switch subCommandOptions {
-            case let .codeOptions(_, _, _, overrideComments, _, _):
+            case let .codeOptions(_, _, _, overrideComments, _, _, _):
                 XCTAssertTrue(overrideComments.value)
             default:
                 XCTAssertTrue(false)
@@ -22,7 +22,7 @@ class CommandLineParserTests: XCTestCase {
         }
         CommandLineParser(arguments: ["bartycrouch", "code", "-p", ".", "-l", ".", "-c"]).parse { commonOptions, subCommandOptions in
             switch subCommandOptions {
-            case let .codeOptions(_, _, _, overrideComments, _, _):
+            case let .codeOptions(_, _, _, overrideComments, _, _, _):
                 XCTAssertTrue(overrideComments.value)
             default:
                 XCTAssertTrue(false)
@@ -33,7 +33,7 @@ class CommandLineParserTests: XCTestCase {
     func testIfCommentCommandIsNotAdded() {
         CommandLineParser(arguments: ["bartycrouch", "translate", "-p", ".", "-i", "no", "-s", "abc", "-l", ".", "--override-comments"]).parse { commonOptions, subCommandOptions in
             switch subCommandOptions {
-            case let .codeOptions(_, _, _, overrideComments, _, _):
+            case let .codeOptions(_, _, _, overrideComments, _, _, _):
                 XCTAssertTrue(!overrideComments.value)
             default:
                 XCTAssertTrue(true)
@@ -41,7 +41,7 @@ class CommandLineParserTests: XCTestCase {
         }
         CommandLineParser(arguments: ["bartycrouch", "translate", "-p", ".", "-i", "no", "-s", "abc", "-l", ".", "-c"]).parse { commonOptions, subCommandOptions in
             switch subCommandOptions {
-            case let .codeOptions(_, _, _, overrideComments, _, _):
+            case let .codeOptions(_, _, _, overrideComments, _, _, _):
                 XCTAssertTrue(!overrideComments.value)
             default:
                 XCTAssertTrue(true)
@@ -49,7 +49,7 @@ class CommandLineParserTests: XCTestCase {
         }
         CommandLineParser(arguments: ["bartycrouch", "interfaces", "-p", ".", "-i", "no", "--override-comments"]).parse { commonOptions, subCommandOptions in
             switch subCommandOptions {
-            case let .codeOptions(_, _, _, overrideComments, _, _):
+            case let .codeOptions(_, _, _, overrideComments, _, _, _):
                 XCTAssertTrue(!overrideComments.value)
             default:
                 XCTAssertTrue(true)
@@ -57,7 +57,7 @@ class CommandLineParserTests: XCTestCase {
         }
         CommandLineParser(arguments: ["bartycrouch", "interfaces", "-p", ".", "-c"]).parse { commonOptions, subCommandOptions in
             switch subCommandOptions {
-            case let .codeOptions(_, _, _, overrideComments, _, _):
+            case let .codeOptions(_, _, _, overrideComments, _, _, _):
                 XCTAssertTrue(!overrideComments.value)
             default:
                 XCTAssertTrue(true)
@@ -65,7 +65,7 @@ class CommandLineParserTests: XCTestCase {
         }
         CommandLineParser(arguments: ["bartycrouch", "code", "-p", ".", "-l", "."]).parse { commonOptions, subCommandOptions in
             switch subCommandOptions {
-            case let .codeOptions(_, _, _, overrideComments, _, _):
+            case let .codeOptions(_, _, _, overrideComments, _, _, _):
                 XCTAssertTrue(!overrideComments.value)
             default:
                 XCTAssertTrue(true)

--- a/Tests/Code/CommandLineParserTests.swift
+++ b/Tests/Code/CommandLineParserTests.swift
@@ -8,7 +8,7 @@
 
 import XCTest
 
-@testable import BartyCrouchFramework
+@testable import BartyCrouchKit
 
 class CommandLineParserTests: XCTestCase {
     func testIfCommentCommandIsAdded() {

--- a/Tests/Code/ExtractLocStringsCommanderTests.swift
+++ b/Tests/Code/ExtractLocStringsCommanderTests.swift
@@ -13,64 +13,79 @@ import XCTest
 class ExtractLocStringsCommanderTests: XCTestCase {
     // MARK: - Stored Properties
 
-    let baseMultipleArgumentTestCodeDirectory = "\(BASE_DIR)/Tests/Assets/Multiple Arguments Code"
+    let baseMultipleArgumentTestCodeFunctionNamesAndDirectories : [(String?, String)] = [
+     (nil, "\(BASE_DIR)/Tests/Assets/Multiple Arguments Code"),
+     ("BCLocalizedString", "\(BASE_DIR)/Tests/Assets/Multiple Arguments Code Custom Function")
+    ]
 
     override func tearDown() {
-        removeLocalizableStringsFilesRecursively(in: URL(fileURLWithPath: baseMultipleArgumentTestCodeDirectory))
+        for (_, directory) in baseMultipleArgumentTestCodeFunctionNamesAndDirectories {
+            removeLocalizableStringsFilesRecursively(in: URL(fileURLWithPath: directory))
+        }
     }
-
 
     // MARK: - Test Methods
 
     func test2Arguments() {
-        assert(
-            ExtractLocStringsCommander.shared,
-            takesCodeIn: "\(baseMultipleArgumentTestCodeDirectory)/2 Arguments",
-            producesResult: [
-                "/* test comment */",
-                "\"test\" = \"test\";",
-                "",
-                ""
-            ]
-        )
+        for (functionName, directory) in baseMultipleArgumentTestCodeFunctionNamesAndDirectories {
+            assert(
+                ExtractLocStringsCommander.shared,
+                takesCodeIn: "\(directory)/2 Arguments",
+                customFunction: functionName,
+                producesResult: [
+                    "/* test comment */",
+                    "\"test\" = \"test\";",
+                    "",
+                    ""
+                ]
+            )
+        }
     }
 
     func test3ArgumentsValue() {
-        assert(
-            ExtractLocStringsCommander.shared,
-            takesCodeIn: "\(baseMultipleArgumentTestCodeDirectory)/3 Arguments",
-            producesResult: [
-                "/* test comment */",
-                "\"test\" = \"test value\";",
-                "",
-                ""
-            ]
-        )
+        for (functionName, directory) in baseMultipleArgumentTestCodeFunctionNamesAndDirectories {
+            assert(
+                ExtractLocStringsCommander.shared,
+                takesCodeIn: "\(directory)/3 Arguments",
+                customFunction: functionName,
+                producesResult: [
+                    "/* test comment */",
+                    "\"test\" = \"test value\";",
+                    "",
+                    ""
+                ]
+            )
+        }
     }
 
     func test4ArgumentsBundleValue() {
-        assert(
-            ExtractLocStringsCommander.shared,
-            takesCodeIn: "\(baseMultipleArgumentTestCodeDirectory)/4 Arguments",
-            producesResult: [
-                "/* test comment */",
-                "\"test\" = \"test value\";",
-                "",
-                ""
-            ]
-        )
+        for (functionName, directory) in baseMultipleArgumentTestCodeFunctionNamesAndDirectories {
+            assert(
+                ExtractLocStringsCommander.shared,
+                takesCodeIn: "\(directory)/4 Arguments",
+                customFunction: functionName,
+                producesResult: [
+                    "/* test comment */",
+                    "\"test\" = \"test value\";",
+                    "",
+                    ""
+                ]
+            )
+        }
     }
 
-    func assert(_ codeCommander: CodeCommander, takesCodeIn directory: String, producesResult expectedLocalizableContentLines: [String]) {
-        let exportSuccess = codeCommander.export(stringsFilesToPath: directory, fromCodeInDirectoryPath: directory, customFunction: nil)
-        XCTAssertTrue(exportSuccess)
+    func assert(_ codeCommander: CodeCommander, takesCodeIn directory: String, customFunction: String?,
+                producesResult expectedLocalizableContentLines: [String]) {
+        let exportSuccess = codeCommander.export(stringsFilesToPath: directory, fromCodeInDirectoryPath: directory, customFunction: customFunction)
+        XCTAssertTrue(exportSuccess, "Failed for \(directory) with function \"\(customFunction ?? "NSLocalizedString")\"")
 
         do {
             let contentsOfStringsFile = try String(contentsOfFile: directory + "/Localizable.strings")
             let linesInStringsFile = contentsOfStringsFile.components(separatedBy: CharacterSet.newlines)
-            XCTAssertEqual(linesInStringsFile, expectedLocalizableContentLines)
+            XCTAssertEqual(linesInStringsFile, expectedLocalizableContentLines, "Failed for \(directory) with function \"\(customFunction ?? "NSLocalizedString")\"")
         } catch {
-            XCTFail()
+            XCTFail("Failed for \(directory) with function \"\(customFunction ?? "NSLocalizedString")\"")
+
         }
     }
 

--- a/Tests/Code/ExtractLocStringsCommanderTests.swift
+++ b/Tests/Code/ExtractLocStringsCommanderTests.swift
@@ -8,7 +8,7 @@
 
 import XCTest
 
-@testable import BartyCrouchFramework
+@testable import BartyCrouchKit
 
 class ExtractLocStringsCommanderTests: XCTestCase {
     // MARK: - Stored Properties

--- a/Tests/Code/ExtractLocStringsCommanderTests.swift
+++ b/Tests/Code/ExtractLocStringsCommanderTests.swift
@@ -62,7 +62,7 @@ class ExtractLocStringsCommanderTests: XCTestCase {
     }
 
     func assert(_ codeCommander: CodeCommander, takesCodeIn directory: String, producesResult expectedLocalizableContentLines: [String]) {
-        let exportSuccess = codeCommander.export(stringsFilesToPath: directory, fromCodeInDirectoryPath: directory)
+        let exportSuccess = codeCommander.export(stringsFilesToPath: directory, fromCodeInDirectoryPath: directory, customFunction: nil)
         XCTAssertTrue(exportSuccess)
 
         do {

--- a/Tests/Code/ExtractLocStringsCommanderTests.swift
+++ b/Tests/Code/ExtractLocStringsCommanderTests.swift
@@ -8,7 +8,7 @@
 
 import XCTest
 
-@testable import BartyCrouch
+@testable import BartyCrouchFramework
 
 class ExtractLocStringsCommanderTests: XCTestCase {
     // MARK: - Stored Properties

--- a/Tests/Code/GenStringsCommanderTests.swift
+++ b/Tests/Code/GenStringsCommanderTests.swift
@@ -29,7 +29,9 @@ class GenStringsCommanderTests: XCTestCase {
     // MARK: - Test Methods
 
     func testCodeExamples() {
-        let exportSuccess = GenStringsCommander.shared.export(stringsFilesToPath: exampleCodeFilesDirectoryPath, fromCodeInDirectoryPath: exampleCodeFilesDirectoryPath)
+        let exportSuccess = GenStringsCommander.shared.export(stringsFilesToPath: exampleCodeFilesDirectoryPath,
+                                                              fromCodeInDirectoryPath: exampleCodeFilesDirectoryPath,
+                                                              customFunction: nil)
 
         do {
             let contentsOfStringsFile = try String(contentsOfFile: exampleCodeFilesDirectoryPath + "/Localizable.strings")

--- a/Tests/Code/GenStringsCommanderTests.swift
+++ b/Tests/Code/GenStringsCommanderTests.swift
@@ -8,7 +8,7 @@
 
 import XCTest
 
-@testable import BartyCrouchFramework
+@testable import BartyCrouchKit
 
 class GenStringsCommanderTests: XCTestCase {
     // MARK: - Stored Properties

--- a/Tests/Code/GenStringsCommanderTests.swift
+++ b/Tests/Code/GenStringsCommanderTests.swift
@@ -8,7 +8,7 @@
 
 import XCTest
 
-@testable import BartyCrouch
+@testable import BartyCrouchFramework
 
 class GenStringsCommanderTests: XCTestCase {
     // MARK: - Stored Properties

--- a/Tests/Code/GenStringsCommanderTests.swift
+++ b/Tests/Code/GenStringsCommanderTests.swift
@@ -13,14 +13,18 @@ import XCTest
 class GenStringsCommanderTests: XCTestCase {
     // MARK: - Stored Properties
 
-    let exampleCodeFilesDirectoryPath = "\(BASE_DIR)/Tests/Assets/Code Files"
-
+    let exampleCodeFilesFunctionNamesAndDirectoryPaths : [(String?, String)] = [
+        (nil, "\(BASE_DIR)/Tests/Assets/Code Files"),
+        ("BCLocalizedString", "\(BASE_DIR)/Tests/Assets/Code Files Custom Function")
+    ]
 
     // MARK: - Test Configuration Methods
 
     override func tearDown() {
         do {
-            try FileManager.default.removeItem(atPath: exampleCodeFilesDirectoryPath + "/Localizable.strings")
+            for (_, path) in exampleCodeFilesFunctionNamesAndDirectoryPaths {
+                try FileManager.default.removeItem(atPath: path + "/Localizable.strings")
+            }
         } catch {
             // do nothing
         }
@@ -29,46 +33,48 @@ class GenStringsCommanderTests: XCTestCase {
     // MARK: - Test Methods
 
     func testCodeExamples() {
-        let exportSuccess = GenStringsCommander.shared.export(stringsFilesToPath: exampleCodeFilesDirectoryPath,
-                                                              fromCodeInDirectoryPath: exampleCodeFilesDirectoryPath,
-                                                              customFunction: nil)
+        for (customFunction, path) in exampleCodeFilesFunctionNamesAndDirectoryPaths {
 
-        do {
-            let contentsOfStringsFile = try String(contentsOfFile: exampleCodeFilesDirectoryPath + "/Localizable.strings")
+            let exportSuccess = GenStringsCommander.shared.export(stringsFilesToPath: path,
+                                                                  fromCodeInDirectoryPath: path,
+                                                                  customFunction: customFunction)
 
-            let linesInStringsFile = contentsOfStringsFile.components(separatedBy: .newlines)
-            XCTAssertEqual(linesInStringsFile, [
-                "/* No comment provided by engineer. */",
-                "\"%010d and %03.f\" = \"%1$d and %2$.f\";",
-                "",
-                "/* No comment provided by engineer. */",
-                "\"%@ and %.2f\" = \"%1$@ and %2$.2f\";",
-                "",
-                "/* Ignoring stringsdict key #bc-ignore! */",
-                "\"%d ignore(s)\" = \"%d ignore(s)\";",
-                "",
-                "/* No comment provided by engineer. */",
-                "\"ccc\" = \"ccc\";",
-                "",
-                "/* (test comment with brackets) */",
-                "\"test.brackets_comment\" = \"test.brackets_comment\";",
-                "",
-                "/* test comment 1",
-                "   test comment 2 */",
-                "\"test.multiline_comment\" = \"test.multiline_comment\";",
-                "",
-                "/* Comment for TestKey1 */",
-                "\"TestKey1\" = \"TestKey1\";",
-                "",
-                "/* Comment for TestKey1 */",
-                "\"TestKey2\" = \"TestKey2\";",
-                "",
-                ""
-            ])
-        } catch {
-            XCTFail()
+            do {
+                let contentsOfStringsFile = try String(contentsOfFile: path + "/Localizable.strings")
+
+                let linesInStringsFile = contentsOfStringsFile.components(separatedBy: .newlines)
+                XCTAssertEqual(linesInStringsFile, [
+                    "/* No comment provided by engineer. */",
+                    "\"%010d and %03.f\" = \"%1$d and %2$.f\";",
+                    "",
+                    "/* No comment provided by engineer. */",
+                    "\"%@ and %.2f\" = \"%1$@ and %2$.2f\";",
+                    "",
+                    "/* Ignoring stringsdict key #bc-ignore! */",
+                    "\"%d ignore(s)\" = \"%d ignore(s)\";",
+                    "",
+                    "/* No comment provided by engineer. */",
+                    "\"ccc\" = \"ccc\";",
+                    "",
+                    "/* (test comment with brackets) */",
+                    "\"test.brackets_comment\" = \"test.brackets_comment\";",
+                    "",
+                    "/* test comment 1",
+                    "   test comment 2 */",
+                    "\"test.multiline_comment\" = \"test.multiline_comment\";",
+                    "",
+                    "/* Comment for TestKey1 */",
+                    "\"TestKey1\" = \"TestKey1\";",
+                    "",
+                    "/* Comment for TestKey1 */",
+                    "\"TestKey2\" = \"TestKey2\";",
+                    "",
+                    ""
+                    ], "Failed for \(path) with function \"\(customFunction ?? "NSLocalizedString")\"")
+            } catch {
+                XCTFail("Failed for \(path) with function \"\(customFunction ?? "NSLocalizedString")\"")
+            }
+            XCTAssertTrue(exportSuccess, "Failed for \(path) with function \"\(customFunction ?? "NSLocalizedString")\"")
         }
-
-        XCTAssertTrue(exportSuccess)
     }
 }

--- a/Tests/Code/IBToolCommanderTests.swift
+++ b/Tests/Code/IBToolCommanderTests.swift
@@ -8,7 +8,7 @@
 
 import XCTest
 
-@testable import BartyCrouchFramework
+@testable import BartyCrouchKit
 
 class IBToolCommanderTests: XCTestCase {
     func testiOSExampleStoryboard() {

--- a/Tests/Code/IBToolCommanderTests.swift
+++ b/Tests/Code/IBToolCommanderTests.swift
@@ -8,7 +8,7 @@
 
 import XCTest
 
-@testable import BartyCrouch
+@testable import BartyCrouchFramework
 
 class IBToolCommanderTests: XCTestCase {
     func testiOSExampleStoryboard() {

--- a/Tests/Code/StringsFileUpdaterTests.swift
+++ b/Tests/Code/StringsFileUpdaterTests.swift
@@ -11,7 +11,7 @@
 
 import XCTest
 
-@testable import BartyCrouchFramework
+@testable import BartyCrouchKit
 
 class StringsFileUpdaterTests: XCTestCase { // swiftlint:disable:this type_body_length
     // MARK: - Stored Instance Properties

--- a/Tests/Code/StringsFileUpdaterTests.swift
+++ b/Tests/Code/StringsFileUpdaterTests.swift
@@ -11,7 +11,7 @@
 
 import XCTest
 
-@testable import BartyCrouch
+@testable import BartyCrouchFramework
 
 class StringsFileUpdaterTests: XCTestCase { // swiftlint:disable:this type_body_length
     // MARK: - Stored Instance Properties

--- a/Tests/Code/StringsFilesSearchTests.swift
+++ b/Tests/Code/StringsFilesSearchTests.swift
@@ -8,7 +8,7 @@
 
 import XCTest
 
-@testable import BartyCrouchFramework
+@testable import BartyCrouchKit
 
 class StringsFilesSearchTests: XCTestCase {
     // MARK: - Test Methods

--- a/Tests/Code/StringsFilesSearchTests.swift
+++ b/Tests/Code/StringsFilesSearchTests.swift
@@ -8,7 +8,7 @@
 
 import XCTest
 
-@testable import BartyCrouch
+@testable import BartyCrouchFramework
 
 class StringsFilesSearchTests: XCTestCase {
     // MARK: - Test Methods


### PR DESCRIPTION
Hey there, I'm currently looking into some string extraction, found this tool (Thanks!! :-)), but I do have custom localisation functions. So this is mainly based on #14. I rebased it, fixed some merge issues and added tests for both the new and the genstrings extractor.

I also changed the short-option as "-c" was already taken by now. Given "-s" is already used as well (the genstrings option), I don't really have an opinion and just went with "-f" for function :-) 

The tests didn't build for me. (I used the framework-scheme and ran the tests). If those work for you, I can just remove the commit working around that issue.

Let me know what you think! 