### PR TITLE
Remove superfluous disable command of swiftlint.

### DIFF
--- a/Sources/Code/StringsFileUpdater.swift
+++ b/Sources/Code/StringsFileUpdater.swift
@@ -7,7 +7,6 @@
 //
 
 // swiftlint:disable function_body_length
-// swiftlint:disable file_length
 
 import Foundation
 


### PR DESCRIPTION
This disable command is no longer required and therefore produces an error.