### PR TITLE
Fixes issue 66

### DIFF
--- a/Sources/Code/Commander.swift
+++ b/Sources/Code/Commander.swift
@@ -32,21 +32,21 @@ class Commander {
         task.standardError = errpipe
 
         task.launch()
-
+        
+        var errors: [String] = []
+        let errdata = errpipe.fileHandleForReading.readDataToEndOfFile()
+        
+        if var string = String(data: errdata, encoding: .utf8) {
+            string = string.trimmingCharacters(in: .newlines)
+            errors = string.components(separatedBy: "\n")
+        }
+        
         var outputs: [String] = []
         let outdata = outpipe.fileHandleForReading.readDataToEndOfFile()
 
         if var string = String(data: outdata, encoding: .utf8) {
             string = string.trimmingCharacters(in: .newlines)
             outputs = string.components(separatedBy: "\n")
-        }
-
-        var errors: [String] = []
-        let errdata = errpipe.fileHandleForReading.readDataToEndOfFile()
-
-        if var string = String(data: errdata, encoding: .utf8) {
-            string = string.trimmingCharacters(in: .newlines)
-            errors = string.components(separatedBy: "\n")
         }
 
         task.waitUntilExit()

--- a/Tests/Code/StringsFilesSearchTests.swift
+++ b/Tests/Code/StringsFilesSearchTests.swift
@@ -21,7 +21,7 @@ class StringsFilesSearchTests: XCTestCase {
         let results = StringsFilesSearch.shared.findAllIBFiles(within: basePath, withLocale: "Base")
 
         XCTAssertEqual(results.count, expectedIBFilePaths.count)
-        XCTAssertEqual(results, expectedIBFilePaths)
+        XCTAssertEqual(results.sorted(), expectedIBFilePaths.sorted())
     }
 
     func testFindAllStringsFiles() {
@@ -33,7 +33,7 @@ class StringsFilesSearchTests: XCTestCase {
         let results = StringsFilesSearch.shared.findAllStringsFiles(within: basePath, withLocale: "de")
 
         XCTAssertEqual(results.count, expectedStringsFilePaths.count)
-        XCTAssertEqual(results, expectedStringsFilePaths)
+        XCTAssertEqual(results.sorted(), expectedStringsFilePaths.sorted())
     }
 
     func testiOSFindAllLocalesForStringsFile() {
@@ -43,7 +43,7 @@ class StringsFilesSearchTests: XCTestCase {
         let results = StringsFilesSearch.shared.findAllLocalesForStringsFile(sourceFilePath: baseStoryboardPath)
 
         XCTAssertEqual(results.count, expectedStringsPaths.count)
-        XCTAssertEqual(results, expectedStringsPaths)
+        XCTAssertEqual(results.sorted(), expectedStringsPaths.sorted())
     }
 
 


### PR DESCRIPTION
Fixes issue #66 : hangs with ibtool on XCode 9 (and possible other shell commands)
Fixes reproducibility of file search tests