### PR TITLE
Added ability to ignore empty & whitespace strings

### DIFF
--- a/Sources/Code/CommandLineActor.swift
+++ b/Sources/Code/CommandLineActor.swift
@@ -39,8 +39,8 @@ public class CommandLineActor {
                 sortByKeys: sortByKeys.value, unstripped: unstripped.value, customFunction: customFunction.value
             )
 
-        case let .interfacesOptions(defaultToBaseOption, unstripped):
-            self.actOnInterfaces(path: path, override: override, verbose: verbose, defaultToBase: defaultToBaseOption.value, unstripped: unstripped.value)
+        case let .interfacesOptions(defaultToBaseOption, unstripped, ignoreEmptyStrings):
+            self.actOnInterfaces(path: path, override: override, verbose: verbose, defaultToBase: defaultToBaseOption.value, unstripped: unstripped.value, ignoreEmptyStrings: ignoreEmptyStrings.value)
 
         case let .translateOptions(idOption, secretOption, localeOption):
             guard let id = idOption.value else {
@@ -85,7 +85,7 @@ public class CommandLineActor {
         )
     }
 
-    private func actOnInterfaces(path: String, override: Bool, verbose: Bool, defaultToBase: Bool, unstripped: Bool) {
+    private func actOnInterfaces(path: String, override: Bool, verbose: Bool, defaultToBase: Bool, unstripped: Bool, ignoreEmptyStrings: Bool) {
         let inputFilePaths = StringsFilesSearch.shared.findAllIBFiles(within: path, withLocale: "Base")
 
         guard !inputFilePaths.isEmpty else {
@@ -109,7 +109,7 @@ public class CommandLineActor {
             }
 
             self.incrementalInterfacesUpdate(
-                inputFilePath, outputStringsFilePaths, override: override, verbose: verbose, defaultToBase: defaultToBase, unstripped: unstripped
+                inputFilePath, outputStringsFilePaths, override: override, verbose: verbose, defaultToBase: defaultToBase, unstripped: unstripped, ignoreEmptyStrings: ignoreEmptyStrings
             )
         }
     }
@@ -195,7 +195,7 @@ public class CommandLineActor {
     }
 
     private func incrementalInterfacesUpdate(
-        _ inputFilePath: String, _ outputStringsFilePaths: [String], override: Bool, verbose: Bool, defaultToBase: Bool, unstripped: Bool
+        _ inputFilePath: String, _ outputStringsFilePaths: [String], override: Bool, verbose: Bool, defaultToBase: Bool, unstripped: Bool, ignoreEmptyStrings: Bool
     ) {
         let extractedStringsFilePath = inputFilePath + ".tmpstrings"
 
@@ -214,7 +214,8 @@ public class CommandLineActor {
                 withStringsFileAtPath: extractedStringsFilePath,
                 addNewValuesAsEmpty: !defaultToBase,
                 override: override,
-                keepWhitespaceSurroundings: unstripped
+                keepWhitespaceSurroundings: unstripped,
+                ignoreEmptyStrings: ignoreEmptyStrings
             )
 
             if verbose {

--- a/Sources/Code/CommandLineParser.swift
+++ b/Sources/Code/CommandLineParser.swift
@@ -28,7 +28,7 @@ public class CommandLineParser {
             localizable: StringOption, defaultToKeys: BoolOption, additive: BoolOption, overrideComments: BoolOption,
             useExtractLocStrings: BoolOption, sortByKeys: BoolOption, unstripped: BoolOption, customFunction: StringOption
         )
-        case interfacesOptions(defaultToBase: BoolOption, unstripped: BoolOption)
+        case interfacesOptions(defaultToBase: BoolOption, unstripped: BoolOption, ignoreEmptyStrings: BoolOption)
         case translateOptions(id: StringOption, secret: StringOption, locale: StringOption)
     }
 
@@ -195,11 +195,15 @@ public class CommandLineParser {
             shortFlag: "u", longFlag: "unstripped", required: false,
             helpMessage: "Keep newlines at beginning/end of Strings files."
         )
+        let ignoreEmptyStrings = BoolOption(
+            shortFlag: "i", longFlag: "ignore-empty-strings", required: false,
+            helpMessage: "Ignores empty strings and strings consisting of whitespace only."
+        )
 
         let commonOptions: CommonOptions = (path: path, override: override, verbose: verbose)
-        let subCommandOptions = SubCommandOptions.interfacesOptions(defaultToBase: defaultToBase, unstripped: unstripped)
+        let subCommandOptions = SubCommandOptions.interfacesOptions(defaultToBase: defaultToBase, unstripped: unstripped, ignoreEmptyStrings: ignoreEmptyStrings)
 
-        commandLine.addOptions(path, override, verbose, defaultToBase, unstripped)
+        commandLine.addOptions(path, override, verbose, defaultToBase, unstripped, ignoreEmptyStrings)
         return (commandLine, commonOptions, subCommandOptions)
     }
 

--- a/Sources/Code/StringsFileUpdater.swift
+++ b/Sources/Code/StringsFileUpdater.swift
@@ -37,7 +37,7 @@ public class StringsFileUpdater {
         withStringsFileAtPath otherStringFilePath: String,
         addNewValuesAsEmpty: Bool, ignoreBaseKeysAndComment ignores: [String] = defaultIgnoreKeys,
         override: Bool = false, updateCommentWithBase: Bool = true, keepExistingKeys: Bool = false,
-        overrideComments: Bool = false, sortByKeys: Bool = false, keepWhitespaceSurroundings: Bool = false
+        overrideComments: Bool = false, sortByKeys: Bool = false, keepWhitespaceSurroundings: Bool = false, ignoreEmptyStrings: Bool = false
     ) {
         do {
             let newContentString = try String(contentsOfFile: otherStringFilePath)
@@ -61,6 +61,7 @@ public class StringsFileUpdater {
                 for newTranslation in newTranslations {
                     // skip keys marked for ignore
                     guard !newTranslation.value.containsAny(of: ignores) else { continue }
+                    if ignoreEmptyStrings && newTranslation.value.trimmingCharacters(in: .whitespaces).isEmpty { continue }
 
                     // Skip keys that have been marked for ignore in comment
                     if let newComment = newTranslation.comment, newComment.containsAny(of: ignores) { continue }


### PR DESCRIPTION
When having empty strings (consisting of whitespace only) in the storyboard there is now an option to not add them to the strings file. For example, you might have a whitespace only string on the back button in the navigation bar.

This adds the command line option `i` (long version `ignore-empty-strings`), which enables the option.