### PR TITLE
Escaped the name arguments to please `find`

### DIFF
--- a/Sources/Code/CodeCommander.swift
+++ b/Sources/Code/CodeCommander.swift
@@ -16,7 +16,7 @@ extension CodeCommander {
     func findFiles(in codeDirectoryPath: String) -> Commander.CommandLineResult {
         return Commander.shared.run(
             command: "/usr/bin/find",
-            arguments: [codeDirectoryPath, "-name", "\"*.[hm]\"", "-o", "-name", "\"*.mm\"", "-o", "-name", "\"*.swift\""]
+            arguments: [codeDirectoryPath, "-name", "*.h", "-o", "-name", "*.m", "-o", "-name", "*.mm", "-o", "-name", "*.swift"]
         )
     }
 }

--- a/Sources/Code/CodeCommander.swift
+++ b/Sources/Code/CodeCommander.swift
@@ -16,7 +16,7 @@ extension CodeCommander {
     func findFiles(in codeDirectoryPath: String) -> Commander.CommandLineResult {
         return Commander.shared.run(
             command: "/usr/bin/find",
-            arguments: [codeDirectoryPath, "-name", "*.[hm]", "-o", "-name", "*.mm", "-o", "-name", "*.swift"]
+            arguments: [codeDirectoryPath, "-name", "\"*.[hm]\"", "-o", "-name", "\"*.mm\"", "-o", "-name", "\"*.swift\""]
         )
     }
 }


### PR DESCRIPTION
See #72 

This solves the indefinite hang, I'm not exactly sure as to why we need to escape these characters.

A colleague of mine had the same setup as me but he wasn't experiencing the indefinite hang and we weren't able to pin-point the differences.