### PR TITLE
Support for Swift Package Manager!

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -29,10 +29,10 @@ disabled_rules:
 included:
 - Sources
 - Tests
+- Package.swift
 
 excluded:
 - Carthage
-- Package.swift
 - UsageExamples.playground
 
 line_length: 160

--- a/BartyCrouch CLI/main.swift
+++ b/BartyCrouch CLI/main.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import BartyCrouchKit
 
 func run() {
     CommandLineParser().parse { commonOptions, subCommandOptions in

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,37 @@
+// swift-tools-version:4.0
+import PackageDescription
+
+let package = Package(
+    name: "BartyCrouch",
+    products: [
+        .executable(name: "bartycrouch", targets: ["BartyCrouch CLI"]),
+        .library(name: "BartyCrouchKit", targets: ["BartyCrouchKit"])
+    ],
+    dependencies: [
+    ],
+    targets: [
+        .target(
+            name: "BartyCrouchKit",
+            dependencies: [
+            ],
+            path: ".",
+            sources: [
+                "Sources/Code",
+                "Carthage/CommandLine",
+                "Carthage/Handyswift",
+                "Carthage/Polyglot"
+            ]
+        ),
+        .target(
+            name: "BartyCrouch CLI",
+            dependencies: [
+                "BartyCrouchKit"
+            ],
+            path: ".",
+            sources: [
+                "BartyCrouch CLI/"
+            ]
+        )
+    ],
+    swiftLanguageVersions: [4]
+)

--- a/Sources/Code/CommandLineActor.swift
+++ b/Sources/Code/CommandLineActor.swift
@@ -16,6 +16,9 @@ public enum CommandLineAction {
 }
 
 public class CommandLineActor {
+
+    public init() {}
+
     // MARK: - Instance Methods
     public func act(commonOptions: CommandLineParser.CommonOptions, subCommandOptions: CommandLineParser.SubCommandOptions) {
         guard let path = commonOptions.path.value else {


### PR DESCRIPTION
Resolves #82 

## TL;DR

I created Package.swift for SPM. 
And to do it, I modified some source files.
But I didn't add the test target `BartyCrouchTests` for SPM because of a ObjC file. 

---

First of all, I wrote `target` in Package.swift like this:

```swift
        .target(
            name: "BartyCrouchKit",
            dependencies: [
            ],
            path: ".",
            sources: [
                "Sources/Code",
                "Carthage/CommandLine",
                "Carthage/Handyswift",
                "Carthage/Polyglot"
            ]
        ),
        .target(
            name: "BartyCrouch CLI",
            dependencies: [
                "BartyCrouchKit"
            ],
            path: ".",
            sources: [
                "Sources/Code",
                "Carthage/CommandLine",
                "Carthage/Handyswift",
                "Carthage/Polyglot",
                "BartyCrouch CLI/"
                ]
            ),
```

This is almost the same as the Xcode's setting `Compile Sources`, 
But it shows the following error.

```swift
error: target 'BartyCrouch CLI' has sources overlapping sources: /Users/abc/workspace/BartyCrouch/Carthage/Handyswift/Extensions/CharacterViewExtension.swift, ...
```

It looks SPM doesn't allow sharing same source files for multiple targets.
So I modified the code like this:

```
.target(
    name: "BartyCrouchKit",
    dependencies: [
    ],
    path: ".",
    sources: [
        "Sources/Code",
        "Carthage/CommandLine",
        "Carthage/Handyswift",
        "Carthage/Polyglot"
    ]
),
.target(
    name: "BartyCrouch CLI",
    dependencies: [
        "BartyCrouchKit"
    ],
    path: ".",
    sources: [
        "BartyCrouch CLI/"
        ]
    ),
```

Then `BartyCrouch CLI/main.swift` needed  `import BartyCrouchKit`. 
And CommandLineActor needed a public initializer.
So I added them.

I made sure this PR works fine in my environment. Building on Xcode and CocoaPods as well.

But I didn't make `testTarget`
I tried to write a `target` for tests like this:

```swift
.testTarget(
    name: "BartyCrouchKitTests",
    dependencies: [
        "BartyCrouchKit"
    ],
    path: "Tests"
)
```

But when I ran `swift test` then this error was displayed:

> error: target at '/Users/abc/workspace/BartyCrouch/Tests' contains mixed language source files; feature not supported

It looks SPM doesn't allow ObjC files, i.e. `Tests/Supporting Files/Constants.m`.

In the file, a preprocessor macro `PROJECT_DIR` is used.
It is why it is not a swift file, right? You know swift can't handle it.

Probably there are some nicer ways to get rid of the macro. But I think it makes pretty big refactoring.
And unit tests on Xcode is still available.
So I didn't add `testTarget` to Package.swift.
Sorry for my laziness...