### PR TITLE
Don't rewrite files if they didn't change

### DIFF
--- a/Sources/BartyCrouchKit/FileHandling/StringsFileUpdater.swift
+++ b/Sources/BartyCrouchKit/FileHandling/StringsFileUpdater.swift
@@ -198,10 +198,10 @@ public class StringsFileUpdater {
                 newContentsOfFile = whitespacesOrNewlinesAtBegin + newContentsOfFile.stripped() + whitespacesOrNewlinesAtEnd
             }
 
-            try FileManager.default.removeItem(atPath: path)
-            try newContentsOfFile.write(toFile: path, atomically: true, encoding: .utf8)
-
-            self.oldContentString = try String(contentsOfFile: path)
+            if newContentsOfFile != self.oldContentString {
+                try newContentsOfFile.write(toFile: path, atomically: true, encoding: .utf8)
+                self.oldContentString = newContentsOfFile
+            }
         } catch {
             print(error.localizedDescription, level: .error)
         }


### PR DESCRIPTION
**Don't rewrite files if they didn't change**
This provides a 50+% speed improvement incremental builds on my project (30+ seconds down to less than 10-15). Not because Barty Crouch is faster, but because Xcode doesn't feel the need to rebuild xibs whose strings files Barty Crouch has touched, and then re-link and re-sign frameworks whose strings files or xibs changed.

**Also, avoid unnecessary I/O when the file did change**
Writing the file atomically means there's no need to remove it first (and in fact, we avoid accidentally messing with special permissions and attributes), and we already know the new content of the file 'cos we just wrote it out, so there's no need to re-read it from disk. It's a minor speed improvement, but seems worth having.