### PR TITLE
Re-add Makefile step to create CocoaPods zip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,12 @@ install: bartycrouch
 	@install -d "$(bindir)" "$(libdir)"
 	@install "$(BUILDDIR)/release/bartycrouch" "$(bindir)"
 
+.PHONY: portable_zip
+portable_zip: bartycrouch
+	rm -f "$(BUILDDIR)/release/portable_bartycrouch.zip"
+	zip -j "$(BUILDDIR)/release/portable_bartycrouch.zip" "$(BUILDDIR)/release/bartycrouch" "$(REPODIR)/LICENSE"
+	echo "Portable ZIP created at: $(BUILDDIR)/release/portable_bartycrouch.zip"
+
 .PHONY: uninstall
 uninstall:
 	@rm -rf "$(bindir)/bartycrouch"


### PR DESCRIPTION
Fixes #118.

So at some point the `portable_zip` step was removed to add SPM & Mint support. This resolves that issue.

Note: to actually fix #118, the `podspec` will need to be updated as well, and the generated ZIP attached to the release.