### PR TITLE
Make BartyCrouch fast again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Removed
 - None.
 ### Fixed
-- None.
+- Make Code Transform, Normalize & Lint fast again (up to 50x faster). Fixes [#128](https://github.com/Flinesoft/BartyCrouch/issues/128) by [Frederick Pietschmann](https://github.com/fredpi).
 ### Security
 - None.
 

--- a/Sources/BartyCrouchKit/FileHandling/StringsFileUpdater.swift
+++ b/Sources/BartyCrouchKit/FileHandling/StringsFileUpdater.swift
@@ -323,12 +323,12 @@ public class StringsFileUpdater {
 
         // swiftlint:disable force_try
         let translationRegex = try! NSRegularExpression(pattern: translationRegexString, options: [.dotMatchesLineSeparators, .anchorsMatchLines])
-//        let newlineRegex = try! NSRegularExpression(pattern: "(\\n)", options: .useUnixLineSeparators)
+        let newlineRegex = try! NSRegularExpression(pattern: "(\\n)", options: .useUnixLineSeparators)
         // swiftlint:enable force_try
 
-//        let positionsOfNewlines = SortedArray(
-//            newlineRegex.matches(in: string, options: .reportCompletion, range: string.fullRange).map { $0.range(at: 1).location }
-//        )
+        let positionsOfNewlines = SortedArray(
+            newlineRegex.matches(in: string, options: .reportCompletion, range: string.fullRange).map { $0.range(at: 1).location }
+        )
 
         let matches = translationRegex.matches(in: string, options: .reportCompletion, range: string.fullRange)
         var translations: [TranslationEntry] = []
@@ -343,8 +343,7 @@ public class StringsFileUpdater {
                     if range.location != NSNotFound && range.length > 0 { comment = (string as NSString).substring(with: range) }
                 }
 
-                let line: Int = string.prefix(valueRange.location).components(separatedBy: .newlines).count
-//                let numberOfNewlines = positionsOfNewlines.index { $0 > valueRange.location + valueRange.length } ?? positionsOfNewlines.array.count
+                let line = (positionsOfNewlines.index { $0 > valueRange.location + valueRange.length } ?? positionsOfNewlines.array.count) + 1
                 return TranslationEntry(key: key, value: value, comment: comment, line: line)
             }
         }


### PR DESCRIPTION
This PR closes #128. The only change is that the line number is no longer resolved by each match individually, instead, a linebreak → index map is created once per file, that can then be used by each individual match to get the corresponding line quickly.

When adjusting the line algorithm, I noticed that this was actually already implemented before, but then commented out for some reason. I guess it's still valid to take this approach again, as this resolves the huge speed problem present since Xcode 10.2.