### PR TITLE
Handling long list of arguments for extractLocStrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ If needed, pluralize to `Tasks`, `PRs` or `Authors` and list multiple entries se
 ### Removed
 - None.
 ### Fixed
-- None.
+- Fixed crashes in projects with large number of files. Fixes [#92](https://github.com/Flinesoft/BartyCrouch/issues/92) & [#99](https://github.com/Flinesoft/BartyCrouch/issues/99) by [Christos Koninis](https://github.com/csknns).
 ### Security
 - None.
 

--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ tasks = ["interfaces", "code", "transform", "normalize"]
 - `customFunction`: Use alternative name to `NSLocalizedString`.
 - `customLocalizableName`: Use alternative name for `Localizable.strings`.
 - `unstripped`: Keeps whitespaces at beginning & end of Strings files.
+- `usesPlistForExtractLocStringsArguments`: Use a plist file to store all the code files for the ExtractLocStrings tool.
 
 </details>
 

--- a/Sources/BartyCrouchKit/Configuration/Options/UpdateOptions/CodeOptions.swift
+++ b/Sources/BartyCrouchKit/Configuration/Options/UpdateOptions/CodeOptions.swift
@@ -9,6 +9,7 @@ struct CodeOptions {
     let customFunction: String?
     let customLocalizableName: String?
     let unstripped: Bool
+    let usesPlistForExtractLocStringsArguments: Bool?
 }
 
 extension CodeOptions: TomlCodable {
@@ -23,7 +24,8 @@ extension CodeOptions: TomlCodable {
             additive: toml.bool(update, code, "additive") ?? true,
             customFunction: toml.string(update, code, "customFunction"),
             customLocalizableName: toml.string(update, code, "customLocalizableName"),
-            unstripped: toml.bool(update, code, "unstripped") ?? false
+            unstripped: toml.bool(update, code, "unstripped") ?? false,
+            usesPlistForExtractLocStringsArguments: toml.bool(update, code, "usesPlistForExtractLocStringsArguments")
         )
     }
 
@@ -44,6 +46,10 @@ extension CodeOptions: TomlCodable {
         }
 
         lines.append("unstripped = \(unstripped)")
+
+        if let usesPlistForExtractLocStringsArguments = usesPlistForExtractLocStringsArguments {
+            lines.append("usesPlistForExtractLocStringsArguments = \(usesPlistForExtractLocStringsArguments)")
+        }
 
         return lines.joined(separator: "\n")
     }

--- a/Sources/BartyCrouchKit/OldCommandLine/CodeCommander.swift
+++ b/Sources/BartyCrouchKit/OldCommandLine/CodeCommander.swift
@@ -22,13 +22,18 @@ public final class CodeCommander {
     public static let shared = CodeCommander()
 
     // MARK: - Instance Methods
-    public func export(stringsFilesToPath stringsFilePath: String, fromCodeInDirectoryPath codeDirectoryPath: String, customFunction: String?) throws {
+    public func export(
+        stringsFilesToPath stringsFilePath: String,
+        fromCodeInDirectoryPath codeDirectoryPath: String,
+        customFunction: String?,
+        usesPlistForExtractLocStringsArguments: Bool?
+    ) throws {
         let files = try findFiles(in: codeDirectoryPath)
         let customFunctionArgs = customFunction != nil ? ["-s", "\(customFunction!)"] : []
 
         let argumentsWithoutTheFiles = ["extractLocStrings"] + ["-o", stringsFilePath] + customFunctionArgs + ["-q"]
 
-        let arguments = try appendFiles(files, inListOfArguments: argumentsWithoutTheFiles)
+        let arguments = try appendFiles(files, inListOfArguments: argumentsWithoutTheFiles, usesPlistForExtractLocStringsArguments)
         try Task.run("/usr/bin/xcrun", arguments: arguments)
     }
 
@@ -61,10 +66,13 @@ public final class CodeCommander {
 
     // In the existing list of arguments it appends also the files arguments. Depending on the total length of the argument list we either append them in the
     // argument list or write them in a file and append that file.
-    func appendFiles(_ files: [String], inListOfArguments existingArguments: [String]) throws -> [String] {
+    func appendFiles(_ files: [String], inListOfArguments existingArguments: [String], _ usesPlistForExtractLocStringsArguments: Bool?) throws -> [String] {
         let completeArgumentList = existingArguments + files
+        let disableUsageOfPlistForArgumentList = !(usesPlistForExtractLocStringsArguments ?? true)
+        let forceUsageOfPlistForArgumentList = usesPlistForExtractLocStringsArguments ?? false
 
-        if Task.isArgumentListTooLong(completeArgumentList) {
+        // If the flag is not set we will autodetect if we need to use a plist file
+        if forceUsageOfPlistForArgumentList || ( !disableUsageOfPlistForArgumentList && Task.isArgumentListTooLong(completeArgumentList)) {
             // If the argument list gets to long we write the files in a plist and pass that as argument
             let fileArgumentsPlistFile = try ExtractLocStrings().writeFilesArgumentsInPlist(files)
             return existingArguments + ["-f", fileArgumentsPlistFile]

--- a/Sources/BartyCrouchKit/OldCommandLine/CommandLineActor.swift
+++ b/Sources/BartyCrouchKit/OldCommandLine/CommandLineActor.swift
@@ -25,7 +25,8 @@ public class CommandLineActor {
         overrideComments: Bool,
         unstripped: Bool,
         customFunction: String?,
-        customLocalizableName: String?
+        customLocalizableName: String?,
+        usesPlistForExtractLocStringsArguments: Bool?
     ) {
         let localizableFileName = customLocalizableName ??  "Localizable"
         let allLocalizableStringsFilePaths = localizables.flatMap {
@@ -47,7 +48,8 @@ public class CommandLineActor {
             overrideComments: overrideComments,
             unstripped: unstripped,
             customFunction: customFunction,
-            localizableFileName: localizableFileName
+            localizableFileName: localizableFileName,
+            usesPlistForExtractLocStringsArguments: usesPlistForExtractLocStringsArguments
         )
     }
 
@@ -212,7 +214,8 @@ public class CommandLineActor {
         overrideComments: Bool,
         unstripped: Bool,
         customFunction: String?,
-        localizableFileName: String
+        localizableFileName: String,
+        usesPlistForExtractLocStringsArguments: Bool?
     ) {
         for inputDirectoryPath in inputDirectoryPaths {
             let extractedStringsFileDirectory = inputDirectoryPath + "/tmpstrings/"
@@ -228,7 +231,8 @@ public class CommandLineActor {
                 try CodeCommander.shared.export(
                     stringsFilesToPath: extractedStringsFileDirectory,
                     fromCodeInDirectoryPath: inputDirectoryPath,
-                    customFunction: customFunction
+                    customFunction: customFunction,
+                    usesPlistForExtractLocStringsArguments: usesPlistForExtractLocStringsArguments
                 )
             } catch {
                 print("Could not extract strings from Code in directory '\(inputDirectoryPath)'.", level: .error)

--- a/Sources/BartyCrouchKit/OldCommandLine/Extensions/TaskExtension.swift
+++ b/Sources/BartyCrouchKit/OldCommandLine/Extensions/TaskExtension.swift
@@ -1,0 +1,31 @@
+//  Created by Christos Koninis on 25/09/2019.
+
+import Foundation
+import SwiftCLI
+
+// Task extentions to querry the limitations of the Task's argument list
+extension Task {
+    // Method to determent if the argument list is to long to pass to new process
+    static func isArgumentListTooLong(_ argumentList: [String]) -> Bool {
+        // Get maximum length of arguments for a new process (in Bytes) and the maximum count for the list for arguments. See
+        // https://www.in-ulm.de/~mascheck/various/argmax/ for more info.
+        guard
+            let maxArgumentLength = resultForGetconfCommand("expr `getconf ARG_MAX` - `env|wc -c` - `env|wc -l` \\* 4 - 2048"),
+            let maxArgumentCount = resultForGetconfCommand("expr `getconf _POSIX_ARG_MAX`")
+            else {
+            return false
+        }
+
+        let argumentListLength = argumentList.joined(separator: " ").utf8.count
+        let isArgumentListLengthTooLong = maxArgumentLength < argumentListLength
+        let isArgumentListCountTooLong = maxArgumentCount < argumentList.count + ProcessInfo.processInfo.environment.keys.count
+
+        return isArgumentListLengthTooLong || isArgumentListCountTooLong
+    }
+
+    private static func resultForGetconfCommand(_ getconfCommand: String) -> Int? {
+        guard let commandResult = try? Task.capture(bash: getconfCommand) else { return nil }
+
+        return Int(commandResult.stdout)
+    }
+}

--- a/Sources/BartyCrouchKit/OldCommandLine/Extensions/TaskExtension.swift
+++ b/Sources/BartyCrouchKit/OldCommandLine/Extensions/TaskExtension.swift
@@ -10,15 +10,16 @@ extension Task {
         // Get maximum length of arguments for a new process (in Bytes) and the maximum count for the list for arguments. See
         // https://www.in-ulm.de/~mascheck/various/argmax/ for more info.
         guard
-            let maxArgumentLength = resultForGetconfCommand("expr `getconf ARG_MAX` - `env|wc -c` - `env|wc -l` \\* 4 - 2048"),
-            let maxArgumentCount = resultForGetconfCommand("expr `getconf _POSIX_ARG_MAX`")
+            let maxArgumentLength = resultForGetconfCommand("expr `getconf ARG_MAX` \\/ 2 - `env|wc -c` - `env|wc -l` \\* 4 - 2048"),
+            let maxArgumentCount = resultForGetconfCommand("expr `getconf _POSIX_ARG_MAX`"),
+            let argumentListData = argumentList.joined(separator: " ").data(using: .utf8)
             else {
-            return false
+            return true
         }
 
-        let argumentListLength = argumentList.joined(separator: " ").utf8.count
+        let argumentListLength = argumentListData.count
         let isArgumentListLengthTooLong = maxArgumentLength < argumentListLength
-        let isArgumentListCountTooLong = maxArgumentCount < argumentList.count + ProcessInfo.processInfo.environment.keys.count
+        let isArgumentListCountTooLong = maxArgumentCount < argumentList.count
 
         return isArgumentListLengthTooLong || isArgumentListCountTooLong
     }

--- a/Sources/BartyCrouchKit/OldCommandLine/ExtractLocStrings.swift
+++ b/Sources/BartyCrouchKit/OldCommandLine/ExtractLocStrings.swift
@@ -1,0 +1,53 @@
+//  Created by Christos Koninis on 25/09/2019.
+
+import Foundation
+
+/// Class to handle extractLocStrings's tool file argument list. It provides methods to serialize the file list to an argument plist file. See
+/// https://github.com/Flinesoft/BartyCrouch/issues/92
+class ExtractLocStrings {
+    /// extractLocStrings tools supports instead of passing files as arguments in the command line to pass a plist with the files. This is the format of that
+    /// plist.
+    struct File: Codable, Equatable {
+        var path: String
+    }
+    struct ArgumentsPlist: Codable, Equatable {
+        var files: [File] = []
+
+        init(filePaths: [String]) {
+            files = filePaths.map(File.init)
+        }
+    }
+
+    /// Serializes the extractLocStrings's file arguments to an argument plist file.
+    ///
+    /// - Parameter files: A array containing the list of files.
+    /// - Returns: The argument plist file that contains the list of file arguments.
+    /// - Throws: An error if any value throws an error during plist encoding.
+    func writeFilesArgumentsInPlist(_ files: [String]) throws -> String {
+        let data = try encodeFilesArguments(files)
+        let tempPlistFilePath = createTemporaryArgumentsPlistFile()
+        try data.write(to: tempPlistFilePath)
+
+        return tempPlistFilePath.path
+    }
+
+    /// Serializes the extractLocStrings's file arguments to byte array
+    ///
+    /// - Parameter files: A array containing the list of files.
+    /// - Returns: A plist encoded value of the supplied array
+    func encodeFilesArguments(_ files: [String]) throws -> Data {
+        let encoder = PropertyListEncoder()
+        encoder.outputFormat = .xml
+
+        return try encoder.encode(ArgumentsPlist(filePaths: files))
+    }
+
+    private func createTemporaryArgumentsPlistFile() -> URL {
+        let temporaryFilename = ProcessInfo().globallyUniqueString
+        var temporaryPath = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        temporaryPath.appendPathComponent(temporaryFilename)
+        temporaryPath.appendPathExtension("plist")
+
+        return temporaryPath
+    }
+}

--- a/Sources/BartyCrouchKit/TaskHandlers/CodeTaskHandler.swift
+++ b/Sources/BartyCrouchKit/TaskHandlers/CodeTaskHandler.swift
@@ -22,7 +22,8 @@ extension CodeTaskHandler: TaskHandler {
                     overrideComments: false,
                     unstripped: options.unstripped,
                     customFunction: options.customFunction,
-                    customLocalizableName: options.customLocalizableName
+                    customLocalizableName: options.customLocalizableName,
+                    usesPlistForExtractLocStringsArguments: options.usesPlistForExtractLocStringsArguments
                 )
             }
         }

--- a/Tests/BartyCrouchKitTests/CommandLine/ExtractLocStringsTests.swift
+++ b/Tests/BartyCrouchKitTests/CommandLine/ExtractLocStringsTests.swift
@@ -1,0 +1,29 @@
+//  Created by Christos Koninis on 25/09/2019.
+
+@testable import BartyCrouchKit
+import XCTest
+
+// swiftlint:disable force_try
+
+class ExtractLocStringsTests: XCTestCase {
+    func testEncodedArgumentPlistFormat() {
+        let files = ["file.m", "otherfile.swift", "/path/of/anotherfile.swift"]
+        // Disabling whitespace_comment_start due to false positives
+        // swiftlint:disable whitespace_comment_start
+        let expectedArgumentsPlistString = """
+            <?xml version=\"1.0\" encoding=\"UTF-8\"?><!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
+            <plist version=\"1.0\"><dict><key>files</key><array><dict><key>path</key><string>file.m</string></dict><dict><key>path</key><string>otherfile.swift\
+            </string></dict><dict><key>path</key><string>/path/of/anotherfile.swift</string></dict></array></dict></plist>
+            """
+
+        let argumentsPlistData = try! ExtractLocStrings().encodeFilesArguments(files)
+        let argumentsPlist = try! argumentsPlistFromData(argumentsPlistData)
+        let expectedArgumentsPlist = try! argumentsPlistFromData(expectedArgumentsPlistString.data(using: .utf8)!)
+
+        XCTAssertEqual(argumentsPlist, expectedArgumentsPlist)
+    }
+
+    private func argumentsPlistFromData(_ data: Data) throws -> ExtractLocStrings.ArgumentsPlist {
+        return try PropertyListDecoder().decode(ExtractLocStrings.ArgumentsPlist.self, from: data)
+    }
+}


### PR DESCRIPTION
Handling long list of arguments for extractLocStrings by writing them in a arguments plist file. 

This solves errors that causes crash with Exception: 'Couldn't posix_spawn: error 7'.

Fixes Flinesoft/BartyCrouch#92
This PR with minor modifications can also fix Flinesoft/BartyCrouch#99
