### PR TITLE
Empty line no longer added to start of strings files on sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ If needed, pluralize to `Tasks`, `PRs` or `Authors` and list multiple entries se
 ### Removed
 - None.
 ### Fixed
-- None.
+- Normalize sortByKeys no longer adds empty line to begining of .strings file.
+Issues: [#178](https://github.com/Flinesoft/BartyCrouch/issues/178)
 ### Security
 - None.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,8 @@ If needed, pluralize to `Tasks`, `PRs` or `Authors` and list multiple entries se
 ### Removed
 - None.
 ### Fixed
-- Normalize sortByKeys no longer adds empty line to begining of .strings file.
-Issues: [#178](https://github.com/Flinesoft/BartyCrouch/issues/178)
+- Normalize sortByKeys no longer adds empty line to begining of .strings file.  
+  Issue: [#178](https://github.com/Flinesoft/BartyCrouch/issues/178) | PR: [#180](https://github.com/Flinesoft/BartyCrouch/pull/180) | Author: [Patrick Wolowicz](https://github.com/hactar)
 ### Security
 - None.
 

--- a/Sources/BartyCrouchKit/FileHandling/StringsFileUpdater.swift
+++ b/Sources/BartyCrouchKit/FileHandling/StringsFileUpdater.swift
@@ -364,7 +364,7 @@ public class StringsFileUpdater {
     }
 
     func stringFromTranslations(translations: [TranslationEntry]) -> String {
-        return "\n" + translations.map { key, value, comment, _ -> String in
+        return translations.map { key, value, comment, _ -> String in
             let translationLine = "\"\(key)\" = \"\(value)\";"
             if let comment = comment { return "/*\(comment)*/\n" + translationLine }
             return translationLine


### PR DESCRIPTION
As discussed in #178 - when normalising and sortByKeys = true, BartyCrouch adds a new line to the start of every strings file. This PR resolves this issue.