### PR TITLE
Remove magic of gathering of new translation via comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ If needed, pluralize to `Tasks`, `PRs` or `Authors` and list multiple entries se
 ### Deprecated
 - None.
 ### Removed
-- None.
+- Removed code magic that used the localization comment from Interface Builder files as a source for new translation values.  
+  Issue: [#140](https://github.com/Flinesoft/BartyCrouch/issues/140) | PR: [#182](https://github.com/Flinesoft/BartyCrouch/pull/182) | Author: [Cihat Gündüz](https://github.com/Jeehut)
 ### Fixed
 - Normalize sortByKeys no longer adds empty line to begining of .strings file.  
   Issue: [#178](https://github.com/Flinesoft/BartyCrouch/issues/178) | PR: [#180](https://github.com/Flinesoft/BartyCrouch/pull/180) | Author: [Patrick Wolowicz](https://github.com/hactar)

--- a/Sources/BartyCrouchKit/FileHandling/StringsFileUpdater.swift
+++ b/Sources/BartyCrouchKit/FileHandling/StringsFileUpdater.swift
@@ -76,15 +76,6 @@ public class StringsFileUpdater {
 
                     let oldTranslation = oldTranslations.first { oldKey, _, _, _ in oldKey == newTranslation.key }
 
-                    // get value from default comment structure if possible
-                    let oldBaseValue: String? = {
-                        guard let oldComment = oldTranslation?.comment, let foundMatch = defaultCommentStructureMatches(inString: oldComment) else {
-                            return nil
-                        }
-
-                        return (oldComment as NSString).substring(with: foundMatch.range(at: 1))
-                    }()
-
                     let updatedComment: String? = {
                         // add new comment if none existed before
                         guard let oldComment = oldTranslation?.comment else { return newTranslation.comment }
@@ -117,8 +108,6 @@ public class StringsFileUpdater {
                         }
 
                         if override { return newTranslationValue } // override with new value in force update mode
-
-                        if let oldBaseValue = oldBaseValue, oldBaseValue == oldValue { return newTranslationValue } // update base value
 
                         // keep existing translation
                         return oldValue


### PR DESCRIPTION
I remember I added this feature to improve the user experience when working with the default behavior of Interface Builder, but I don't remember the details. Also this feature was never documented or tested, so I think it can be removed.

Fingers crossed that there will be no side effects and no one is relying on this. 🤞 

Fixes #140.
