### PR TITLE
Support DeepL API Free

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ If needed, pluralize to `Tasks`, `PRs` or `Authors` and list multiple entries se
 
 ## [Unreleased]
 ### Added
-- None.
+- Add support for DeepL API Free  
+  PR: [#230](https://github.com/Flinesoft/BartyCrouch/pull/230) | Author: [Manabu Nakazawa](https://github.com/mshibanami)
 ### Changed
 - None.
 ### Deprecated

--- a/Sources/BartyCrouchTranslator/BartyCrouchTranslator.swift
+++ b/Sources/BartyCrouchTranslator/BartyCrouchTranslator.swift
@@ -27,13 +27,14 @@ public final class BartyCrouchTranslator {
     /// Creates a new translator object configured to use the specified translation service.
     public init(translationService: TranslationService) {
         self.translationService = translationService
-        
+
         let deepLApiType: DeepLApi.ApiType
         if case let .deepL(apiKey) = translationService {
             deepLApiType = apiKey.hasSuffix(":fx") ? .free : .pro
         } else {
             deepLApiType = .pro
         }
+
         deepLProvider = ApiProvider<DeepLApi>(baseUrl: DeepLApi.baseUrl(for: deepLApiType))
     }
 

--- a/Sources/BartyCrouchTranslator/BartyCrouchTranslator.swift
+++ b/Sources/BartyCrouchTranslator/BartyCrouchTranslator.swift
@@ -20,13 +20,21 @@ public final class BartyCrouchTranslator {
     }
 
     private let microsoftProvider = ApiProvider<MicrosoftTranslatorApi>(baseUrl: MicrosoftTranslatorApi.baseUrl)
-    private let deepLProvider = ApiProvider<DeepLApi>(baseUrl: DeepLApi.baseUrl)
+    private let deepLProvider: ApiProvider<DeepLApi>
 
     private let translationService: TranslationService
 
     /// Creates a new translator object configured to use the specified translation service.
     public init(translationService: TranslationService) {
         self.translationService = translationService
+        
+        let deepLApiType: DeepLApi.ApiType
+        if case let .deepL(apiKey) = translationService {
+            deepLApiType = apiKey.hasSuffix(":fx") ? .free : .pro
+        } else {
+            deepLApiType = .pro
+        }
+        deepLProvider = ApiProvider<DeepLApi>(baseUrl: DeepLApi.baseUrl(for: deepLApiType))
     }
 
     /// Translates the given text from a given language to one or multiple given other languages.

--- a/Sources/BartyCrouchTranslator/DeeplApi/DeepLApi.swift
+++ b/Sources/BartyCrouchTranslator/DeeplApi/DeepLApi.swift
@@ -31,20 +31,11 @@ enum DeepLApi {
 }
 
 extension DeepLApi: Endpoint {
+    typealias ClientErrorType = DeepLTranslateErrorResponse
+
     enum ApiType {
         case free
         case pro
-    }
-
-    typealias ClientErrorType = DeepLTranslateErrorResponse
-
-    static func baseUrl(for apiType: ApiType) -> URL {
-        switch apiType {
-        case .free:
-            return URL(string: "https://api-free.deepl.com")!
-        case .pro:
-            return URL(string: "https://api.deepl.com")!
-        }
     }
 
     var decoder: JSONDecoder {
@@ -84,5 +75,15 @@ extension DeepLApi: Endpoint {
 
     var headers: [String: String] {
         ["Content-Type": "application/json"]
+    }
+
+    static func baseUrl(for apiType: ApiType) -> URL {
+        switch apiType {
+        case .free:
+            return URL(string: "https://api-free.deepl.com")!
+
+        case .pro:
+            return URL(string: "https://api.deepl.com")!
+        }
     }
 }

--- a/Sources/BartyCrouchTranslator/DeeplApi/DeepLApi.swift
+++ b/Sources/BartyCrouchTranslator/DeeplApi/DeepLApi.swift
@@ -31,10 +31,20 @@ enum DeepLApi {
 }
 
 extension DeepLApi: Endpoint {
+    enum ApiType {
+        case free
+        case pro
+    }
+
     typealias ClientErrorType = DeepLTranslateErrorResponse
 
-    static var baseUrl: URL {
-        URL(string: "https://api.deepl.com")!
+    static func baseUrl(for apiType: ApiType) -> URL {
+        switch apiType {
+        case .free:
+            return URL(string: "https://api-free.deepl.com")!
+        case .pro:
+            return URL(string: "https://api.deepl.com")!
+        }
     }
 
     var decoder: JSONDecoder {

--- a/Tests/BartyCrouchTranslatorTests/DeepLTranslatorApiTests.swift
+++ b/Tests/BartyCrouchTranslatorTests/DeepLTranslatorApiTests.swift
@@ -15,7 +15,7 @@ class DeepLTranslatorApiTests: XCTestCase {
             apiKey: apiKey
         )
 
-        let apiProvider = ApiProvider<DeepLApi>(baseUrl: DeepLApi.baseUrl)
+        let apiProvider = ApiProvider<DeepLApi>(baseUrl: DeepLApi.baseUrl(for: .pro))
 
         switch apiProvider.performRequestAndWait(on: endpoint, decodeBodyTo: DeepLTranslateResponse.self) {
         case let .success(translateResponses):


### PR DESCRIPTION
(No related issue.)

## Proposed Changes

  - Support [DeepL API Free](https://support.deepl.com/hc/en-us/articles/360021200939-DeepL-API-Free)
      - DeepL API has 2 domains; `api.deepl.com` for Pro and `api-free.deepl.com` for Free. Currently, BartyCrouch only supports `api.deepl.com`. This PR will add a feature to switch them.
      - To detect whether the user needs to use `api-free.deepl.com` or not, BartyCrouch will check the suffix of the authentication key, that is the official way to identify:  
          > DeepL API Free authentification keys can be identified easily by the suffix ":fx" (e.g., 279a2e9d-83b3-c416-7e2d-f721593e42a0:fx)
          > https://www.deepl.com/docs-api/accessing-the-api/api-versions/
