### PR TITLE
Fix: DeepL translation doesn't work for Simplified Chinese

### DIFF
--- a/Sources/BartyCrouchTranslator/DeeplApi/DeepLApi.swift
+++ b/Sources/BartyCrouchTranslator/DeeplApi/DeepLApi.swift
@@ -65,8 +65,8 @@ extension DeepLApi: Endpoint {
         switch self {
         case let .translate(texts, sourceLanguage, targetLanguage, apiKey):
             urlParameters["text"] = .array(texts)
-            urlParameters["source_lang"] = .string(sourceLanguage.rawValue.capitalized)
-            urlParameters["target_lang"] = .string(targetLanguage.rawValue.capitalized)
+            urlParameters["source_lang"] = sourceLanguage.deepLParameterValue
+            urlParameters["target_lang"] = targetLanguage.deepLParameterValue
             urlParameters["auth_key"] = .string(apiKey)
         }
 
@@ -84,6 +84,17 @@ extension DeepLApi: Endpoint {
 
         case .pro:
             return URL(string: "https://api.deepl.com")!
+        }
+    }
+}
+
+private extension Language {
+    var deepLParameterValue: QueryParameterValue {
+        switch self {
+        case .chineseSimplified:
+            return .string("ZH")
+        default:
+            return .string(rawValue.uppercased())
         }
     }
 }


### PR DESCRIPTION
(No related issue)

## Problem

Suppose you want to translate an English word "Hello" to Simplified Chinese with DeepL API via BartyCrouch.
Currently, BartyCrouch sends a request like this:

```
https://api-free.deepl.com/v2/translate?source_lang=En&text=Hello&target_lang=Zh-Hans&auth_key={auth key}
```

But DeepL doesn't allow `Zh-Hans` for `target_lang` nor `source_lang`, so they always return 400 Bad Request.

This is the documentation of what they allow: https://www.deepl.com/docs-api/translating-text/request/

## Proposed Changes

- Set `ZH` rather than `Zh-Hans` for `target_lang` and `source_lang`
    - I didn't do this for Traditional Chinese because DeepL's `ZH` is actually for Simplified Chinese but I have no strong opinion. Please feel free to suggest me doing this for Traditional Chinese too.
- Change the values of `target_lang` and `source_lang` to UPPER CASE from Capitalised Case
    - This is a kind of refactoring. As of now, both uppercased and capitalized work fine, but I guess we better to use the documented case.

So this PR will change the above URL into this:

```
https://api-free.deepl.com/v2/translate?source_lang=EN&text=Hello&target_lang=ZH&auth_key={your auth key}
```