### PR TITLE
Document list of ignored files / clean up properly after error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,12 @@ func updateTimeLabel(minutes: Int) {
 
 The `%d minute(s) ago` key will be taken from Localizable.stringsdict file, not from Localizable.strings, that's why it should be ignored by BartyCrouch.
 
+### Things to Know:
+
+- Files named or files in folders named ".git", "carthage", "pods", "build", 
+  ".build" and "docs" (case insensitive) will always be ignored.
+
+
 ## Donation
 
 BartyCrouch was brought to you by [Cihat Gündüz](https://github.com/Jeehut) in his free time. If you want to thank me and support the development of this project, please **make a small donation on [PayPal](https://paypal.me/Dschee/5EUR)**. In case you also like my other [open source contributions](https://github.com/Flinesoft) and [articles](https://medium.com/@Jeehut), please consider motivating me by **becoming a sponsor on [GitHub](https://github.com/sponsors/Jeehut)** or a **patron on [Patreon](https://www.patreon.com/Jeehut)**.

--- a/Sources/BartyCrouchKit/OldCommandLine/CommandLineActor.swift
+++ b/Sources/BartyCrouchKit/OldCommandLine/CommandLineActor.swift
@@ -243,6 +243,10 @@ public class CommandLineActor {
             let extractedLocalizableStringsFilePath = extractedStringsFileDirectory + "Localizable.strings"
             guard FileManager.default.fileExists(atPath: extractedLocalizableStringsFilePath) else {
                 print("No localizations extracted from Code in directory '\(inputDirectoryPath)'.", level: .warning)
+                
+                // BUGFIX: Remove empty /tmpstrings/ folder again.
+                try? FileManager.default.removeItem(atPath: extractedStringsFileDirectory)
+                
                 return // NOTE: Expecting to see this only for empty project situations.
             }
 

--- a/Sources/BartyCrouchKit/OldCommandLine/CommandLineActor.swift
+++ b/Sources/BartyCrouchKit/OldCommandLine/CommandLineActor.swift
@@ -243,10 +243,10 @@ public class CommandLineActor {
             let extractedLocalizableStringsFilePath = extractedStringsFileDirectory + "Localizable.strings"
             guard FileManager.default.fileExists(atPath: extractedLocalizableStringsFilePath) else {
                 print("No localizations extracted from Code in directory '\(inputDirectoryPath)'.", level: .warning)
-                
+
                 // BUGFIX: Remove empty /tmpstrings/ folder again.
                 try? FileManager.default.removeItem(atPath: extractedStringsFileDirectory)
-                
+
                 return // NOTE: Expecting to see this only for empty project situations.
             }
 


### PR DESCRIPTION
I spent over one hour to understand what that error message exactly means and why my code wasn't searched.

Please spare others these hour! Thanks!

And consider ignoring the ignore list, when folders are explicitly added. I know, that's a little bigger than one hour.

## Proposed Changes

  - Document ignored files list.
  - Try removing empty `tmpstrings` directory after error.
 

Besides these: Thanks so much for this great tool!