### PR TITLE
Fixed issue #239: Don't ignore explicitly mentioned folders, even tho…

### DIFF
--- a/Sources/BartyCrouchKit/FileHandling/CodeFilesSearch.swift
+++ b/Sources/BartyCrouchKit/FileHandling/CodeFilesSearch.swift
@@ -1,16 +1,21 @@
 import Foundation
 
 final class CodeFilesSearch: FilesSearchable {
+
+    static let dirsToIgnore = Set([".git", "carthage", "pods", "build", ".build", "docs"])
+
     private let baseDirectoryPath: String
+    private let basePathComponents: [String]
 
     init(baseDirectoryPath: String) {
         self.baseDirectoryPath = baseDirectoryPath
+
+        basePathComponents = URL(fileURLWithPath: baseDirectoryPath).pathComponents
     }
 
-    static func shouldSkipFile(at url: URL) -> Bool {
-        let dirsToIgnore = Set([".git", "carthage", "pods", "build", ".build", "docs"])
-        return url.pathComponents.contains { component in
-            dirsToIgnore.contains(component.lowercased())
+    func shouldSkipFile(at url: URL) -> Bool {
+        return Set(url.pathComponents).subtracting(basePathComponents).contains { component in
+            Self.dirsToIgnore.contains(component.lowercased())
         }
     }
 

--- a/Sources/BartyCrouchKit/FileHandling/CodeFilesSearch.swift
+++ b/Sources/BartyCrouchKit/FileHandling/CodeFilesSearch.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 final class CodeFilesSearch: FilesSearchable {
-
     static let dirsToIgnore = Set([".git", "carthage", "pods", "build", ".build", "docs"])
 
     private let baseDirectoryPath: String

--- a/Sources/BartyCrouchKit/FileHandling/FilesSearchable.swift
+++ b/Sources/BartyCrouchKit/FileHandling/FilesSearchable.swift
@@ -15,9 +15,10 @@ extension FilesSearchable {
 
         var filePaths = [String]()
         let baseDirectoryAbsolutePath = baseDirectoryURL.path
+        let cfs = CodeFilesSearch(baseDirectoryPath: baseDirectoryAbsolutePath)
 
         for case let url as URL in enumerator {
-            if CodeFilesSearch.shouldSkipFile(at: url) {
+            if cfs.shouldSkipFile(at: url) {
                 enumerator.skipDescendants()
                 continue
             }

--- a/Sources/BartyCrouchKit/OldCommandLine/CodeCommander.swift
+++ b/Sources/BartyCrouchKit/OldCommandLine/CodeCommander.swift
@@ -54,10 +54,11 @@ public final class CodeCommander {
         }
 
         var matchedFiles = [String]()
+        let cfs = CodeFilesSearch(baseDirectoryPath: codeDirectoryPath)
 
         while let anURL = enumerator.nextObject() as? URL {
             if CodeCommanderConstants.sourceCodeExtensions.contains(anURL.pathExtension) &&
-                !CodeFilesSearch.shouldSkipFile(at: anURL) {
+                !cfs.shouldSkipFile(at: anURL) {
                 matchedFiles.append(anURL.path)
             }
         }


### PR DESCRIPTION
…ugh they might contain otherwise ignored folders as their parent folders.

Fixes #239

## Proposed Changes

  - Cuts off user-given base folders, only checks automatically scanned folders therein, if they contain an ignored item.

As discussed on the issue!
