### PR TITLE
Updated Makefile to create a universal binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ all: bartycrouch
 bartycrouch: $(SOURCES)
 	@swift build \
 		-c release \
+		--arch arm64 --arch x86_64 \
 		--disable-sandbox \
 		--build-path "$(BUILDDIR)"
 


### PR DESCRIPTION
Fixes #245

## Proposed Changes

  - Running `make` will now create a universal binary:
```
> lipo -archs .build/apple/Products/Release/bartyCrouch   
x86_64 arm64
```
